### PR TITLE
Remove global separator opacity override

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -918,12 +918,6 @@ window.narrow .category-tile {
 	transform: rotate(270deg);
 }
 
-@media (prefers-color-scheme: dark) {
-  separator {
-	  opacity: 0.5;
-  }
-}
-
 .disable-adw-flow-box-styling {
     background-color: transparent;
     box-shadow: none;


### PR DESCRIPTION
This was needed in some previous design of the update card, don't ask me why I didn't scope it properly