### PR TITLE
Update devcontainer configuration and Dockerfile dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,4 +23,6 @@ RUN dnf update -y && dnf install -y \
     webkitgtk6.0-devel \
     libsecret-devel \
     libproxy-devel \
+    gtksourceview5-devel \
+    glib-networking \
     clangd

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"runArgs": [
+		"--device=/dev/dri",
+		"--network=host"
+	],
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": "false",
@@ -25,9 +29,12 @@
 	"containerEnv": {
 		"WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
 		"XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
-		"XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}"
+		"XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}",
+
+		"DBUS_SYSTEM_BUS_ADDRESS": "unix:path=/var/run/dbus/system_bus_socket"
 	},
 	"mounts": [
-		"source=${localEnv:XDG_RUNTIME_DIR},target=${localEnv:XDG_RUNTIME_DIR},type=bind,consistency=cached"
+		"source=${localEnv:XDG_RUNTIME_DIR},target=${localEnv:XDG_RUNTIME_DIR},type=bind,consistency=cached",
+		"source=/var/run/dbus/system_bus_socket,target=/var/run/dbus/system_bus_socket,type=bind,consistency=cached"
 	]
 }


### PR DESCRIPTION
1. Add the necessary dependencies to the Dockerfile for successful compilation.
2. The absence of the dbus component within the container causes Bazaar to crash. Exposing the host machine's dbus component within the container allows for its use.

Local testing is working fine; the only issue so far is that the flatpak app is not working.
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/8473d07a-8aeb-43c6-864b-63683f7c9e31" />
