### PR TITLE
Hide graph if it has not enough data points

### DIFF
--- a/src/bz-stats-dialog.blp
+++ b/src/bz-stats-dialog.blp
@@ -10,7 +10,7 @@ template $BzStatsDialog: Adw.BreakpointBin {
     [top]
     Adw.HeaderBar {
       title-widget: Adw.ViewSwitcher switcher_title {
-        visible: bind $invert_boolean($is_null(template.country-model) as <bool>) as <bool>;
+        visible: bind $logical_and($model_has_enough_points(template.model) as <bool>, $invert_boolean($is_null(template.country-model) as <bool>) as <bool>) as <bool>;
         stack: stack;
         policy: wide;
       };
@@ -26,6 +26,7 @@ template $BzStatsDialog: Adw.BreakpointBin {
           name: "graph";
           title: _("Timeline");
           icon-name: "graph2-symbolic";
+          visible: bind $model_has_enough_points(template.model) as <bool>;
 
           child: Box {
             orientation: vertical;

--- a/src/bz-stats-dialog.c
+++ b/src/bz-stats-dialog.c
@@ -35,8 +35,9 @@ struct _BzStatsDialog
   int         total_downloads;
 
   /* Template widgets */
-  BzDataGraph *graph;
-  BzWorldMap  *world_map;
+  AdwViewStack *stack;
+  BzDataGraph  *graph;
+  BzWorldMap   *world_map;
 };
 
 G_DEFINE_FINAL_TYPE (BzStatsDialog, bz_stats_dialog, ADW_TYPE_BREAKPOINT_BIN)
@@ -101,6 +102,10 @@ bz_stats_dialog_set_property (GObject      *object,
     case PROP_MODEL:
       g_clear_object (&self->model);
       self->model = g_value_dup_object (value);
+      if (self->model == NULL || g_list_model_get_n_items (self->model) < 10)
+        adw_view_stack_set_visible_child_name (ADW_VIEW_STACK (self->stack), "map");
+      else
+        adw_view_stack_set_visible_child_name (ADW_VIEW_STACK (self->stack), "graph");
       break;
     case PROP_COUNTRY_MODEL:
       g_clear_object (&self->country_model);
@@ -128,6 +133,15 @@ format_total_downloads (gpointer object,
     return g_strdup_printf (_("%.2fK Total Installs"), value / 1000.0);
   else
     return g_strdup_printf (_("%'d Total Installs"), value);
+}
+
+static gboolean
+model_has_enough_points (gpointer object,
+                         GListModel *model)
+{
+  if (model == NULL)
+    return FALSE;
+  return g_list_model_get_n_items (model) >= 10;
 }
 
 static void
@@ -171,6 +185,8 @@ bz_stats_dialog_class_init (BzStatsDialogClass *klass)
   bz_widget_class_bind_all_util_callbacks (widget_class);
 
   gtk_widget_class_bind_template_callback (widget_class, format_total_downloads);
+  gtk_widget_class_bind_template_callback (widget_class, model_has_enough_points);
+  gtk_widget_class_bind_template_child (widget_class, BzStatsDialog, stack);
   gtk_widget_class_bind_template_child (widget_class, BzStatsDialog, graph);
   gtk_widget_class_bind_template_child (widget_class, BzStatsDialog, world_map);
 }


### PR DESCRIPTION
It won't show until it 10 days, like how Flathub does it. This fixes the issue where an invisible map would render when not having enough points.

<img width="2316" height="1832" alt="image" src="https://github.com/user-attachments/assets/c4525de5-a3f1-496d-a410-afaafb8ac910" />
