### PR TITLE
Stop putting name and icon names of links in entries

### DIFF
--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -202,7 +202,6 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
   g_autoptr (GdkPaintable) thumbnail_paintable         = NULL;
   g_autoptr (GListStore) share_urls                    = NULL;
   g_autofree char *donation_url                        = NULL;
-  g_autofree char *forge_url                           = NULL;
   g_autofree char *ratings_summary                     = NULL;
   g_autoptr (GListStore) version_history               = NULL;
   const char *accent_color_light                       = NULL;
@@ -300,9 +299,8 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
       flathub_url = g_strdup_printf ("https://flathub.org/apps/%s", id);
 
       url = bz_url_new ();
-      bz_url_set_name (url, C_ ("Project URL Type", "Flathub Page"));
+      bz_url_set_id (url, "flathub");
       bz_url_set_url (url, flathub_url);
-      bz_url_set_icon_name (url, "flathub-symbolic");
 
       g_list_store_append (share_urls, url);
     }
@@ -314,51 +312,13 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
       url = as_component_get_url (component, e);
       if (url != NULL)
         {
-          const char *enum_string     = NULL;
-          const char *icon_name       = NULL;
           g_autoptr (BzUrl) share_url = NULL;
 
           switch (e)
             {
-            case AS_URL_KIND_HOMEPAGE:
-              enum_string = C_ ("Project URL Type", "Project Website");
-              icon_name   = "globe-symbolic";
-              break;
-            case AS_URL_KIND_BUGTRACKER:
-              enum_string = C_ ("Project URL Type", "Issue Tracker");
-              icon_name   = "computer-fail-symbolic";
-              break;
-            case AS_URL_KIND_FAQ:
-              enum_string = C_ ("Project URL Type", "FAQ");
-              icon_name   = "help-faq-symbolic";
-              break;
-            case AS_URL_KIND_HELP:
-              enum_string = C_ ("Project URL Type", "Help");
-              icon_name   = "help-browser-symbolic";
-              break;
             case AS_URL_KIND_DONATION:
-              enum_string = C_ ("Project URL Type", "Donate");
-              icon_name   = "heart-filled-symbolic";
               g_clear_pointer (&donation_url, g_free);
               donation_url = g_strdup (url);
-              break;
-            case AS_URL_KIND_TRANSLATE:
-              enum_string = C_ ("Project URL Type", "Translate");
-              icon_name   = "translations-symbolic";
-              break;
-            case AS_URL_KIND_CONTACT:
-              enum_string = C_ ("Project URL Type", "Contact");
-              icon_name   = "mail-send-symbolic";
-              break;
-            case AS_URL_KIND_VCS_BROWSER:
-              enum_string = C_ ("Project URL Type", "Source Code");
-              icon_name   = "code-symbolic";
-              g_clear_pointer (&forge_url, g_free);
-              forge_url = g_strdup (url);
-              break;
-            case AS_URL_KIND_CONTRIBUTE:
-              enum_string = C_ ("Project URL Type", "Contribute");
-              icon_name   = "system-users-symbolic";
               break;
             default:
               break;
@@ -366,9 +326,8 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
 
           share_url = g_object_new (
               BZ_TYPE_URL,
-              "name", enum_string,
+              "id", as_url_kind_to_string (e),
               "url", url,
-              "icon-name", icon_name,
               NULL);
           g_list_store_append (share_urls, share_url);
         }
@@ -698,7 +657,6 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
       "thumbnail-paintable", thumbnail_paintable,
       "share-urls", share_urls,
       "donation-url", donation_url,
-      "forge-url", forge_url,
       "ratings-summary", ratings_summary,
       "version-history", version_history,
       "light-accent-color", accent_color_light,

--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -106,7 +106,6 @@ typedef struct
   GdkPaintable     *thumbnail_paintable;
   GListModel       *share_urls;
   char             *donation_url;
-  char             *forge_url;
   char             *ratings_summary;
   GListModel       *version_history;
   char             *light_accent_color;
@@ -174,7 +173,6 @@ enum
   PROP_THUMBNAIL_PAINTABLE,
   PROP_SHARE_URLS,
   PROP_DONATION_URL,
-  PROP_FORGE_URL,
   PROP_RATINGS_SUMMARY,
   PROP_VERSION_HISTORY,
   PROP_IS_FLATHUB,
@@ -368,9 +366,6 @@ bz_entry_get_property (GObject    *object,
       break;
     case PROP_DONATION_URL:
       g_value_set_string (value, priv->donation_url);
-      break;
-    case PROP_FORGE_URL:
-      g_value_set_string (value, priv->forge_url);
       break;
     case PROP_RATINGS_SUMMARY:
       g_value_set_string (value, priv->ratings_summary);
@@ -583,10 +578,6 @@ bz_entry_set_property (GObject      *object,
     case PROP_DONATION_URL:
       g_clear_pointer (&priv->donation_url, g_free);
       priv->donation_url = g_value_dup_string (value);
-      break;
-    case PROP_FORGE_URL:
-      g_clear_pointer (&priv->forge_url, g_free);
-      priv->forge_url = g_value_dup_string (value);
       break;
     case PROP_RATINGS_SUMMARY:
       g_clear_pointer (&priv->ratings_summary, g_free);
@@ -900,12 +891,6 @@ bz_entry_class_init (BzEntryClass *klass)
           NULL, NULL, NULL,
           G_PARAM_READWRITE);
 
-  props[PROP_FORGE_URL] =
-      g_param_spec_string (
-          "forge-url",
-          NULL, NULL, NULL,
-          G_PARAM_READWRITE);
-
   props[PROP_RATINGS_SUMMARY] =
       g_param_spec_string (
           "ratings-summary",
@@ -1205,27 +1190,24 @@ bz_entry_real_serialize (BzSerializable  *serializable,
         {
           g_autoptr (GVariantBuilder) sub_builder = NULL;
 
-          sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(sss)"));
+          sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(ss)"));
           for (guint i = 0; i < n_items; i++)
             {
               g_autoptr (BzUrl) url = NULL;
-              const char *name      = NULL;
+              const char *id        = NULL;
               const char *url_str   = NULL;
-              const char *icon_name = NULL;
 
-              url       = g_list_model_get_item (priv->share_urls, i);
-              name      = bz_url_get_name (url);
-              url_str   = bz_url_get_url (url);
-              icon_name = bz_url_get_icon_name (url);
-              g_variant_builder_add (sub_builder, "(sss)", name, url_str, icon_name ? icon_name : "");
+              url     = g_list_model_get_item (priv->share_urls, i);
+              id      = bz_url_get_id (url);
+              url_str = bz_url_get_url (url);
+
+              g_variant_builder_add (sub_builder, "(ss)", id ? id : "", url_str ? url_str : "");
             }
           g_variant_builder_add (builder, "{sv}", "share-urls", g_variant_builder_end (sub_builder));
         }
     }
   if (priv->donation_url != NULL)
     g_variant_builder_add (builder, "{sv}", "donation-url", g_variant_new_string (priv->donation_url));
-  if (priv->forge_url != NULL)
-    g_variant_builder_add (builder, "{sv}", "forge-url", g_variant_new_string (priv->forge_url));
   if (priv->version_history != NULL)
     {
       guint n_items = 0;
@@ -1543,22 +1525,19 @@ bz_entry_real_deserialize (BzSerializable *serializable,
           g_autoptr (GListStore) store      = NULL;
           g_autoptr (GVariantIter) url_iter = NULL;
 
-          store = g_list_store_new (BZ_TYPE_URL);
-
+          store    = g_list_store_new (BZ_TYPE_URL);
           url_iter = g_variant_iter_new (value);
           for (;;)
             {
-              g_autofree char *name      = NULL;
-              g_autofree char *url_str   = NULL;
-              g_autoptr (BzUrl) url      = NULL;
-              g_autofree char *icon_name = NULL;
+              g_autofree char *id      = NULL;
+              g_autofree char *url_str = NULL;
+              g_autoptr (BzUrl) url    = NULL;
 
-              if (!g_variant_iter_next (url_iter, "(sss)", &name, &url_str, &icon_name))
+              if (!g_variant_iter_next (url_iter, "(ss)", &id, &url_str))
                 break;
               url = bz_url_new ();
-              bz_url_set_name (url, name);
+              bz_url_set_id (url, id);
               bz_url_set_url (url, url_str);
-              bz_url_set_icon_name (url, icon_name);
               g_list_store_append (store, url);
             }
 
@@ -1566,8 +1545,6 @@ bz_entry_real_deserialize (BzSerializable *serializable,
         }
       else if (g_strcmp0 (key, "donation-url") == 0)
         priv->donation_url = g_variant_dup_string (value, NULL);
-      else if (g_strcmp0 (key, "forge-url") == 0)
-        priv->forge_url = g_variant_dup_string (value, NULL);
       else if (g_strcmp0 (key, "version-history") == 0)
         {
           g_autoptr (GListStore) store          = NULL;
@@ -2092,17 +2069,6 @@ bz_entry_get_donation_url (BzEntry *self)
   priv = bz_entry_get_instance_private (self);
 
   return priv->donation_url;
-}
-
-const char *
-bz_entry_get_forge_url (BzEntry *self)
-{
-  BzEntryPrivate *priv = NULL;
-
-  g_return_val_if_fail (BZ_IS_ENTRY (self), NULL);
-  priv = bz_entry_get_instance_private (self);
-
-  return priv->forge_url;
 }
 
 BzRepository *
@@ -2847,7 +2813,6 @@ clear_entry (BzEntry *self)
   g_clear_object (&priv->thumbnail_paintable);
   g_clear_object (&priv->share_urls);
   g_clear_pointer (&priv->donation_url, g_free);
-  g_clear_pointer (&priv->forge_url, g_free);
   g_clear_pointer (&priv->ratings_summary, g_free);
   g_clear_object (&priv->version_history);
   g_clear_pointer (&priv->light_accent_color, g_free);

--- a/src/bz-entry.h
+++ b/src/bz-entry.h
@@ -173,9 +173,6 @@ bz_entry_get_url (BzEntry *self);
 const char *
 bz_entry_get_donation_url (BzEntry *self);
 
-const char *
-bz_entry_get_forge_url (BzEntry *self);
-
 BzRepository *
 bz_entry_get_repository (BzEntry    *self,
                          GListModel *repos);

--- a/src/bz-share-list.c
+++ b/src/bz-share-list.c
@@ -44,6 +44,38 @@ enum
 };
 static GParamSpec *props[LAST_PROP] = { 0 };
 
+typedef struct
+{
+  const char *id;
+  const char *display_name;
+  const char *icon_name;
+} UrlInfo;
+
+static const UrlInfo url_info[] = {
+  {     "flathub",    NC_ ("Project URL Type",    "Flathub Page"),       "flathub-symbolic" },
+  {    "homepage",    NC_ ("Project URL Type", "Project Website"),         "globe-symbolic" },
+  {  "bugtracker",    NC_ ("Project URL Type",   "Issue Tracker"), "computer-fail-symbolic" },
+  {         "faq",    NC_ ("Project URL Type",             "FAQ"),      "help-faq-symbolic" },
+  {        "help",    NC_ ("Project URL Type",            "Help"),  "help-browser-symbolic" },
+  {    "donation",    NC_ ("Project URL Type",          "Donate"),  "heart-filled-symbolic" },
+  {   "translate",    NC_ ("Project URL Type",       "Translate"),  "translations-symbolic" },
+  {     "contact",    NC_ ("Project URL Type",         "Contact"),     "mail-send-symbolic" },
+  { "vcs-browser",    NC_ ("Project URL Type",     "Source Code"),          "code-symbolic" },
+  {  "contribute",    NC_ ("Project URL Type",      "Contribute"),  "system-users-symbolic" },
+  {          NULL,                         NULL,                                       NULL }
+};
+
+static const UrlInfo *
+get_url_info (const char *id)
+{
+  for (int i = 0; url_info[i].id != NULL; i++)
+    {
+      if (g_strcmp0 (url_info[i].id, id) == 0)
+        return &url_info[i];
+    }
+  return NULL;
+}
+
 static void
 copy_cb (BzShareList *self,
          GtkButton   *button)
@@ -87,31 +119,29 @@ follow_link_cb (BzShareList *self,
 static AdwActionRow *
 create_url_action_row (BzShareList *self, BzUrl *url_item)
 {
-  g_autofree char *url_string  = NULL;
-  g_autofree char *url_title   = NULL;
-  g_autofree char *icon_name   = NULL;
-  AdwActionRow    *action_row;
-  GtkBox          *suffix_box;
-  GtkButton       *copy_button;
-  GtkButton       *open_button;
-  GtkSeparator    *separator;
-  GtkImage        *prefix_icon;
+  const char    *url_string = NULL;
+  const char    *id         = NULL;
+  const UrlInfo *info       = NULL;
+  AdwActionRow  *action_row;
+  GtkBox        *suffix_box;
+  GtkButton     *copy_button;
+  GtkButton     *open_button;
+  GtkSeparator  *separator;
 
-  g_object_get (url_item,
-                "url", &url_string,
-                "name", &url_title,
-                "icon-name", &icon_name,
-                NULL);
+  url_string = bz_url_get_url (url_item);
+  id         = bz_url_get_id (url_item);
 
+  info       = get_url_info (id);
   action_row = ADW_ACTION_ROW (adw_action_row_new ());
   adw_preferences_row_set_use_markup (ADW_PREFERENCES_ROW (action_row), FALSE);
   adw_preferences_row_set_title (ADW_PREFERENCES_ROW (action_row),
-                                 url_title ? url_title : url_string);
+                                 info ? g_dpgettext2 (NULL, "Project URL Type", info->display_name)
+                                      : url_string);
   adw_action_row_set_subtitle (action_row, url_string);
 
-  if (icon_name != NULL && icon_name[0] != '\0')
+  if (info != NULL && info->icon_name != NULL && info->icon_name[0] != '\0')
     {
-      prefix_icon = GTK_IMAGE (gtk_image_new_from_icon_name (icon_name));
+      GtkImage *prefix_icon = GTK_IMAGE (gtk_image_new_from_icon_name (info->icon_name));
       gtk_image_set_icon_size (prefix_icon, GTK_ICON_SIZE_NORMAL);
       adw_action_row_add_prefix (action_row, GTK_WIDGET (prefix_icon));
     }

--- a/src/bz-url.txt
+++ b/src/bz-url.txt
@@ -3,6 +3,5 @@ name=url
 parent-prefix=g
 parent-name=object
 author=AUTOGEN
-property=name char G_TYPE_STRING string
+property=id char G_TYPE_STRING string
 property=url char G_TYPE_STRING string
-property=icon_name char G_TYPE_STRING string


### PR DESCRIPTION
This of course causes issues when changing languages. As its still cached in the previous language.

Closes #1522

<img width="2132" height="1900" alt="image" src="https://github.com/user-attachments/assets/c8afc68e-5cfc-4618-b45f-8e38b16691db" />
