### PR TITLE
Allow translators to use download icon for "Get" button

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2292,7 +2292,7 @@ msgstr "Obtenir plus d’informations"
 # Dans le contexte d'App Store - "Get" serait plutôt traduit en "Télécharger" ou comme ici en "Installer"
 #: src/bz-rich-app-tile.blp:158
 msgid "Get"
-msgstr "Installer"
+msgstr "/"
 
 #: src/bz-rich-app-tile.blp:173
 msgid "Uninstall"

--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -170,7 +170,7 @@ template $BzRichAppTile: $BzListTile {
 
         StackPage {
           name: "get";
-          child: Button {
+          child: Button get_button {
             sensitive: bind $invert_boolean(
               $is_zero(template.group as <$BzEntryGroup>.installable-and-available) as <bool>
             ) as <bool>;
@@ -179,7 +179,6 @@ template $BzRichAppTile: $BzListTile {
               "medium-pill",
             ]
 
-            label: _("Get");
             valign: center;
             clicked => $install_button_clicked_cb(template);
           };

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -40,6 +40,7 @@ struct _BzRichAppTile
   GListModel                *all_trackers;
 
   GtkWidget          *picture_box;
+  GtkWidget          *get_button;
   BzTransactIconInfo *transact_icon_info;
 };
 
@@ -349,6 +350,7 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, run_button_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, cancel_button_clicked_cb);
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, picture_box);
+  gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, get_button);
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, transact_icon_info);
 
   gtk_widget_class_set_accessible_role (widget_class, GTK_ACCESSIBLE_ROLE_BUTTON);
@@ -357,10 +359,18 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
 static void
 bz_rich_app_tile_init (BzRichAppTile *self)
 {
-  BzStateInfo          *state   = NULL;
-  BzTransactionManager *manager = NULL;
+  BzStateInfo          *state     = NULL;
+  BzTransactionManager *manager   = NULL;
+  const char           *get_label = NULL;
 
   gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* Translators: If you can't find a short enough translation, use "/" to use an icon instead. */
+  get_label = _("Get");
+    if (get_label != NULL && *get_label != '\0' && g_strcmp0 (get_label, "/") != 0)
+      gtk_button_set_label (GTK_BUTTON (self->get_button), get_label);
+    else
+      gtk_button_set_icon_name (GTK_BUTTON (self->get_button), "folder-download-symbolic");
 
   state   = bz_state_info_get_default ();
   manager = bz_state_info_get_transaction_manager (state);

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -366,11 +366,11 @@ bz_rich_app_tile_init (BzRichAppTile *self)
   gtk_widget_init_template (GTK_WIDGET (self));
 
   /* Translators: If you can't find a short enough translation, use "/" to use an icon instead. */
-  get_label = _("Get");
-    if (get_label != NULL && *get_label != '\0' && g_strcmp0 (get_label, "/") != 0)
-      gtk_button_set_label (GTK_BUTTON (self->get_button), get_label);
-    else
-      gtk_button_set_icon_name (GTK_BUTTON (self->get_button), "folder-download-symbolic");
+  get_label = _ ("Get");
+  if (get_label != NULL && *get_label != '\0' && g_strcmp0 (get_label, "/") != 0)
+    gtk_button_set_label (GTK_BUTTON (self->get_button), get_label);
+  else
+    gtk_button_set_icon_name (GTK_BUTTON (self->get_button), "folder-download-symbolic");
 
   state   = bz_state_info_get_default ();
   manager = bz_state_info_get_transaction_manager (state);


### PR DESCRIPTION
Is useful if there isn't a short enough translation available in that language.

<img width="1802" height="1638" alt="image" src="https://github.com/user-attachments/assets/1d2509e0-cc76-417f-93f8-bf7694ed8ff5" />
