### PR TITLE
Hide header bar title for apps page if regular title is visible

### DIFF
--- a/src/bz-apps-page.blp
+++ b/src/bz-apps-page.blp
@@ -5,13 +5,26 @@ template $BzAppsPage: Adw.NavigationPage {
 
   Adw.ToolbarView {
     [top]
-    Adw.HeaderBar {}
+    Adw.HeaderBar {
+
+      [title]
+      Revealer {
+        reveal-child: bind $is_scrolled_down(main_scroll.vadjustment as <Adjustment>.value, carousel.visible) as <bool>;
+        transition-type: slide_up;
+        transition-duration: 500;
+        overflow: visible;
+        child: Label {
+          label: bind template.page-title;
+          styles ["title"]
+        };
+      }
+    }
 
     content: Adw.BreakpointBin {
       width-request: 360;
       height-request: 100;
 
-      child: Gtk.ScrolledWindow {
+      child: Gtk.ScrolledWindow main_scroll {
         hscrollbar-policy: never;
 
         Adw.Clamp {
@@ -26,7 +39,7 @@ template $BzAppsPage: Adw.NavigationPage {
             margin-top: 8;
             margin-bottom: 50;
 
-            $BzFeaturedCarousel {
+            $BzFeaturedCarousel carousel {
               margin-start: 3;
               margin-end: 3;
               margin-bottom: 12;

--- a/src/bz-apps-page.c
+++ b/src/bz-apps-page.c
@@ -194,6 +194,14 @@ is_not_empty_list (gpointer    object,
   return list != NULL && g_list_model_get_n_items (list) > 0;
 }
 
+static gboolean
+is_scrolled_down (gpointer object,
+                  double   value,
+                  gboolean carousel_visible)
+{
+  return value > (carousel_visible ? 400.0 : 50.0);
+}
+
 static void
 featured_carousel_group_clicked_cb (BzAppsPage   *self,
                                     BzEntryGroup *group,
@@ -297,6 +305,7 @@ bz_apps_page_class_init (BzAppsPageClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_not_null);
   gtk_widget_class_bind_template_callback (widget_class, is_not_empty_string);
   gtk_widget_class_bind_template_callback (widget_class, is_not_empty_list);
+  gtk_widget_class_bind_template_callback (widget_class, is_scrolled_down);
   gtk_widget_class_bind_template_callback (widget_class, bind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, unbind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, featured_carousel_group_clicked_cb);


### PR DESCRIPTION
Copies that animation thingy from the full view

<img width="380" height="403" alt="image" src="https://github.com/user-attachments/assets/26d2d044-34fb-4600-9dd3-fbd291d51429" />
