### PR TITLE
chore: actually link to a new website

### DIFF
--- a/bazaar.doap
+++ b/bazaar.doap
@@ -12,7 +12,7 @@
     applications and addons from Flatpak remotes, particularly Flathub.
   </description>
 
-  <homepage rdf:resource="https://github.com/bazaar-org/bazaar" />
+  <homepage rdf:resource="https://usebazaar.org" />
   <download-page rdf:resource="https://github.com/bazaar-org/bazaar/releases" />
   <bug-database rdf:resource="https://github.com/bazaar-org/bazaar/issues" />
 

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -763,7 +763,7 @@ bz_application_about_action (GSimpleAction *action,
       "version", PACKAGE_VCS_VERSION,
       "copyright", "© 2025-2026 The Bazaar Contributors",
       "license-type", GTK_LICENSE_GPL_3_0,
-      "website", "https://github.com/bazaar-org/bazaar",
+      "website", "https://usebazaar.org",
       "issue-url", "https://github.com/bazaar-org/bazaar/issues",
       NULL);
 


### PR DESCRIPTION
Randomly noticed that Bazaar as of 0.8.0 still links to a repo when a proper website exists