### PR TITLE
bge: fix shared library versioning

### DIFF
--- a/bge/meson.build
+++ b/bge/meson.build
@@ -44,9 +44,11 @@ bge_marshalers = gnome.genmarshal('bge-marshalers',
 )
 
 bge_lib = shared_library(
-  'bge-' + api_version,
+  'bge',
   bge_sources, bge_marshalers,
   dependencies: bge_deps,
+       version: api_version,
+       soversion: version_split[0],
        install: true,
 )
 
@@ -59,7 +61,7 @@ pkg.generate(
   description: 'Bazaar GTK Extensions',
     libraries: bge_lib,
          name: 'libbge',
-     filebase: 'bge-' + api_version,
+     filebase: 'bge',
       version: api_version,
       subdirs: 'bge',
      requires: ['gtk4', 'md4c', 'gtksourceview-5'],


### PR DESCRIPTION
I've encountered an issue while packaging Bazaar, caused by the bge library embedding the version in the library's base name.

This patch fixes the issue for me, resulting in the conventional `libbge.so` → `libbge.so.0` → `libbge.so.0.x.x` symlink chain and a stable `bge.pc`.

This change is only required if bge is meant to be a public library, which is the case from what I understood according to #1442.