### PR TITLE
Display a couple of add-ons on the full view

### DIFF
--- a/src/bz-addon-tile.c
+++ b/src/bz-addon-tile.c
@@ -23,6 +23,7 @@
 #include "bz-addon-tile.h"
 #include "bz-addons-dialog.h"
 #include "bz-entry-group.h"
+#include "bz-full-view.h"
 #include "bz-state-info.h"
 #include "bz-window.h"
 
@@ -193,7 +194,8 @@ bz_addon_tile_realize (GtkWidget *widget)
 {
   BzAddonTile *self          = BZ_ADDON_TILE (widget);
   GtkWidget   *parent        = widget;
-  GtkWidget   *addons_dialog = NULL;
+  GtkWidget   *source        = NULL;
+  const char  *prop          = NULL;
 
   GTK_WIDGET_CLASS (bz_addon_tile_parent_class)->realize (widget);
 
@@ -201,17 +203,24 @@ bz_addon_tile_realize (GtkWidget *widget)
     {
       if (BZ_IS_ADDONS_DIALOG (parent))
         {
-          addons_dialog = parent;
+          source = parent;
+          prop   = "parent-ui-entry";
+          break;
+        }
+      else if (BZ_IS_FULL_VIEW (parent))
+        {
+          source = parent;
+          prop   = "ui-entry";
           break;
         }
     }
 
-  if (addons_dialog == NULL)
+  if (source == NULL)
     return;
 
   g_object_bind_property (
-      addons_dialog, "parent-ui-entry",
-      self,          "parent-ui-entry",
+      source, prop,
+      self,   "parent-ui-entry",
       G_BINDING_SYNC_CREATE);
 }
 

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -562,37 +562,78 @@ template $BzFullView: Adw.Bin {
                           };
                         }
 
-                        Adw.PreferencesGroup {
-                          visible: bind $logical_and($invert_boolean($is_null(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.addons) as <bool>) as <bool>, $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <bool>) as <bool>;
-
-                          Adw.ActionRow {
-                            [prefix]
-                            Image {
-                              icon-name: "puzzle-piece-symbolic";
-                            }
-
-                            [suffix]
-                            Image {
-                              icon-name: "go-next-symbolic";
-
-                              styles [
-                                "dimmed",
-                              ]
-                            }
-
-                            title: _("Manage Add-Ons");
-                            activatable: true;
-                            activated => $install_addons_cb(template);
-                          }
-                        }
-
                         $BzReleasesList releases_list {
                           version-history: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.version-history;
                           installed-versions: bind template.entry-group as <$BzEntryGroup>.installed-versions;
                         }
 
-                        $BzShareList {
-                          urls: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.share-urls;
+                        Box {
+                          orientation: vertical;
+                          spacing: bind $choose(addons_more_btn.visible, 15, 3) as <int>;
+                          Box {
+                            orientation: vertical;
+                            visible: bind $invert_boolean($is_zero(addon_model.n-items) as <int>) as <bool>;
+
+                            Label {
+                              styles ["heading"]
+                              halign: start;
+                              label: _("Add-ons");
+                              margin-top: 5;
+                              margin-start: 3;
+                            }
+
+                            ListView {
+                              styles [
+                                "navigation-sidebar",
+                                "installed-list-view",
+                                "full-view-addons"
+                              ]
+                              overflow: visible;
+
+                              model: NoSelection addon_model {
+                                model: bind $get_addon_groups(template.entry-group);
+                              };
+
+                              factory: BuilderListItemFactory {
+                                template ListItem {
+                                  activatable: false;
+                                  selectable: false;
+                                  focusable: false;
+
+                                  child: $BzAddonTile {
+                                    group: bind template.item as <$BzEntryGroup>;
+                                    activated => $addon_tile_activated_cb();
+                                  };
+                                }
+                              };
+                            }
+
+                            Adw.PreferencesGroup addons_more_btn {
+                              visible: bind $should_show_addon_overflow(template.entry-group);
+
+                              Adw.ButtonRow {
+                                title: _("More Add-Ons");
+                                end-icon-name: "go-next-symbolic";
+                                activated => $install_addons_cb(template);
+                              }
+                            }
+                          }
+                          Box {
+                            orientation: vertical;
+
+                            Label {
+                              styles ["heading"]
+                              halign: start;
+                              label: _("Links");
+                              margin-top: 5;
+                              margin-bottom: 8;
+                              margin-start: 3;
+                            }
+
+                            $BzShareList {
+                              urls: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.share-urls;
+                            }
+                          }
                         }
 
                         Box {
@@ -609,7 +650,8 @@ template $BzFullView: Adw.Bin {
                             xalign: 0;
                             wrap: true;
                             wrap-mode: word_char;
-                            margin-bottom: 6;
+                            margin-top: 5;
+                            margin-bottom: 8;
                             margin-start: 3;
                           }
 
@@ -634,7 +676,7 @@ template $BzFullView: Adw.Bin {
                             visible: bind $is_longer(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.developer-apps, 6) as <bool>;
                             clicked => $more_apps_button_clicked_cb(template);
                             halign: center;
-                            margin-top: 11;
+                            margin-top: 15;
                             margin-bottom: 8;
 
                             child: Label {

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -23,6 +23,8 @@
 #include <glib/gi18n.h>
 #include <json-glib/json-glib.h>
 
+#include "bz-addon-tile.h"
+#include "bz-addons-dialog.h"
 #include "bz-age-rating-dialog.h"
 #include "bz-app-size-dialog.h"
 #include "bz-app-tile.h"
@@ -575,6 +577,45 @@ support_cb (BzFullView *self,
     }
 }
 
+static GListModel *
+get_addon_groups (BzFullView   *self,
+                  BzEntryGroup *group)
+{
+  BzApplicationMapFactory *factory = NULL;
+  GListModel              *ids     = NULL;
+  GListModel              *groups  = NULL;
+
+  if (group == NULL)
+    return NULL;
+
+  ids = bz_entry_group_get_addon_group_ids (group);
+  if (ids == NULL)
+    return NULL;
+
+  factory = bz_state_info_get_application_factory (self->state);
+  groups  = bz_application_map_factory_generate (factory, ids);
+  if (groups == NULL)
+    return NULL;
+
+  return G_LIST_MODEL (gtk_slice_list_model_new (groups, 0, 3));
+}
+
+static gboolean
+should_show_addon_overflow (gpointer      object,
+                            BzEntryGroup *group)
+{
+  GListModel *ids = NULL;
+
+  if (group == NULL)
+    return FALSE;
+
+  ids = bz_entry_group_get_addon_group_ids (group);
+  if (ids == NULL)
+    return FALSE;
+
+  return g_list_model_get_n_items (ids) > 3;
+}
+
 static void
 install_addons_cb (BzFullView *self,
                    GtkButton  *button)
@@ -584,6 +625,23 @@ install_addons_cb (BzFullView *self,
 
   gtk_widget_activate_action (GTK_WIDGET (self), "window.addons-group", "s",
                               bz_entry_group_get_id (self->group));
+}
+
+static void
+addon_tile_activated_cb (BzAddonTile *tile)
+{
+  BzFullView   *self   = NULL;
+  BzEntryGroup *group  = NULL;
+  AdwDialog    *dialog = NULL;
+
+  self  = BZ_FULL_VIEW (gtk_widget_get_ancestor (GTK_WIDGET (tile), BZ_TYPE_FULL_VIEW));
+  group = bz_addon_tile_get_group (tile);
+
+  if (group == NULL)
+    return;
+
+  dialog = bz_addons_dialog_new_single (group);
+  adw_dialog_present (dialog, GTK_WIDGET (self));
 }
 
 static int
@@ -723,6 +781,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   g_type_ensure (BZ_TYPE_SHARE_LIST);
   g_type_ensure (BZ_TYPE_TAG_LIST);
   g_type_ensure (BZ_TYPE_CONTEXT_TILE);
+  g_type_ensure (BZ_TYPE_ADDON_TILE);
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-full-view.ui");
   bz_widget_class_bind_all_util_callbacks (widget_class);
@@ -752,7 +811,10 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, delete_user_data_cb);
   gtk_widget_class_bind_template_callback (widget_class, support_cb);
   gtk_widget_class_bind_template_callback (widget_class, pick_license_warning);
+  gtk_widget_class_bind_template_callback (widget_class, get_addon_groups);
+  gtk_widget_class_bind_template_callback (widget_class, should_show_addon_overflow);
   gtk_widget_class_bind_template_callback (widget_class, install_addons_cb);
+  gtk_widget_class_bind_template_callback (widget_class, addon_tile_activated_cb);
   gtk_widget_class_bind_template_callback (widget_class, bind_app_tile_cb);
   gtk_widget_class_bind_template_callback (widget_class, unbind_app_tile_cb);
   gtk_widget_class_bind_template_callback (widget_class, get_description_max_height);

--- a/src/style.css
+++ b/src/style.css
@@ -871,6 +871,18 @@ window.narrow .category-tile {
     margin: 4px 4.5px;
 }
 
+.narrow .full-view-addons > * {
+    margin: 5px 0px;
+}
+
+.full-view-addons > * {
+    margin: 5px 0px;
+}
+
+.full-view-addons {
+    margin: 0px;
+}
+
 .no-vertical-margin > row.hidden {
     margin-top: 0px;
     margin-bottom: 0px;


### PR DESCRIPTION
Makes it so a maximum of 3 add-ons are shown on the full view page, with a button at the bottom to show all add-ons if there are more. This should speed up add-on management in most cases, as most apps only have 1 add-on.

Also adds labels to some sections, similar to what is seen on Flathub. This should make the logical sections easier to parse.

<img width="1240" height="987" alt="Screenshot From 2026-05-23 20-10-26" src="https://github.com/user-attachments/assets/877f6cd7-f871-44f0-8701-90669fae6523" />
<img width="1908" height="1790" alt="Screenshot From 2026-05-23 19-44-13" src="https://github.com/user-attachments/assets/b2ba927a-abe1-4806-8da5-741872ac9e99" />
