### PR TITLE
Disable error due to bad bus policy

### DIFF
--- a/src/bz-app-permissions.c
+++ b/src/bz-app-permissions.c
@@ -717,7 +717,7 @@ bz_app_permissions_new_from_metadata (GKeyFile *keyfile,
               else if (g_str_equal (bus_policy_str, "own"))
                 bus_policy = BZ_BUS_POLICY_PERMISSION_OWN;
               else
-                bus_policy = BZ_BUS_POLICY_PERMISSION_UNKNOWN;
+                continue;
 
               if (app_id != NULL &&
                   bus_policy_types[h].bus_type == G_BUS_TYPE_SESSION &&


### PR DESCRIPTION
org.kde.Platform/x86_64/6.11-beta seems to have an invalid key under [Session Bus Policy] which causes an error at every startup.