### PR TITLE
Select the second screenshot at the start again

### DIFF
--- a/src/bz-screenshots-carousel.blp
+++ b/src/bz-screenshots-carousel.blp
@@ -41,7 +41,7 @@ template $BzScreenshotsCarousel: Gtk.Widget {
           model: bind template.model;
 
           notify::selected => $on_notify_selected(template);
-          notify::n-items => $on_notify_n_items(template);
+          notify::model => $on_notify_model(template);
         };
       }
 

--- a/src/bz-screenshots-carousel.c
+++ b/src/bz-screenshots-carousel.c
@@ -144,8 +144,13 @@ on_notify_selected (BzScreenshotsCarousel *self)
 }
 
 static void
-on_notify_n_items (BzScreenshotsCarousel *self)
+on_notify_model (BzScreenshotsCarousel *self)
 {
+  guint n_items = g_list_model_get_n_items (G_LIST_MODEL (self->selection));
+
+  if (!self->compact && n_items >= 3)
+    gtk_single_selection_set_selected (self->selection, 1);
+
   update_button_visibility (self);
 }
 
@@ -457,7 +462,7 @@ bz_screenshots_carousel_class_init (BzScreenshotsCarouselClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, on_prev_clicked);
   gtk_widget_class_bind_template_callback (widget_class, on_next_clicked);
   gtk_widget_class_bind_template_callback (widget_class, on_notify_selected);
-  gtk_widget_class_bind_template_callback (widget_class, on_notify_n_items);
+  gtk_widget_class_bind_template_callback (widget_class, on_notify_model);
   gtk_widget_class_bind_template_callback (widget_class, on_create_widget);
   gtk_widget_class_bind_template_callback (widget_class, on_remove_widget);
   gtk_widget_class_bind_template_callback (widget_class, on_expand_clicked);


### PR DESCRIPTION
This functionality was lost when moving to the bge-carousel. I also believe I fixed the bug where it seemingly randomly wasn't set to the second one. I believe the reason was that we were checking n-items, but that won't work if the number of screenshots stays the same.