### PR TITLE
Remove pride flag rotation toggle

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -55,10 +55,6 @@
       <summary>Global Progress Bar Theme</summary>
       <description>Describes the look of the global progress bar</description>
     </key>
-    <key name="rotate-flag" type="b">
-      <default>false</default>
-      <summary>Rotate selected flag by 90 degrees</summary>
-    </key>
     <key name="window-dimensions" type="(ii)">
       <default>(1220, 900)</default>
       <summary>Saved Window Dimensions</summary>

--- a/src/bz-install-controls.c
+++ b/src/bz-install-controls.c
@@ -454,11 +454,6 @@ bz_install_controls_set_property (GObject      *object,
                 "changed::global-progress-bar-theme",
                 G_CALLBACK (pride_flag_changed),
                 self);
-            g_signal_connect_swapped (
-                self->settings,
-                "changed::rotate-flag",
-                G_CALLBACK (pride_flag_changed),
-                self);
           }
         ensure_draw_css (self);
       }
@@ -679,12 +674,10 @@ ensure_draw_css (BzInstallControls *self)
       g_autofree char *id       = NULL;
       g_autofree char *final_id = NULL;
       g_autofree char *class    = NULL;
-      gboolean         rotate   = FALSE;
 
-      id     = g_settings_get_string (self->settings, "global-progress-bar-theme");
-      rotate = g_settings_get_boolean (self->settings, "rotate-flag");
+      id = g_settings_get_string (self->settings, "global-progress-bar-theme");
 
-      if (rotate && g_strcmp0 (id, "accent-color") != 0)
+      if (g_strcmp0 (id, "accent-color") != 0)
         final_id = g_strdup_printf ("%s-horizontal", id);
       else
         final_id = g_strdup (id);

--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -80,15 +80,10 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
             row-spacing: 4;
             halign: center;
             homogeneous: true;
-            max-children-per-line: 12;
+            max-children-per-line: 11;
             selection-mode: none;
           }
         };
-      }
-      Adw.SwitchRow rotate_switch {
-        title: _("Vertical Stripes");
-        subtitle: _("Display flag colors from left to right");
-        notify::active => $on_rotate_switch_changed();
       }
     }
   }

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -67,7 +67,6 @@ struct _BzPreferencesDialog
   AdwSwitchRow *search_debounce_switch;
   GtkFlowBox   *flag_buttons_box;
   AdwSwitchRow *hide_eol_switch;
-  AdwSwitchRow *rotate_switch;
 
   GtkToggleButton *flag_buttons[G_N_ELEMENTS (bar_themes)];
 };
@@ -134,22 +133,6 @@ global_progress_theme_settings_changed (BzPreferencesDialog *self,
 }
 
 static void
-on_rotate_switch_changed (AdwSwitchRow        *row,
-                          GParamSpec          *pspec,
-                          BzPreferencesDialog *self)
-{
-  gboolean active = FALSE;
-  active = adw_switch_row_get_active (row);
-  for (guint i = 0; i < G_N_ELEMENTS (bar_themes); i++)
-    {
-      if (active)
-        gtk_widget_add_css_class (GTK_WIDGET (self->flag_buttons[i]), "horizontal");
-      else
-        gtk_widget_remove_css_class (GTK_WIDGET (self->flag_buttons[i]), "horizontal");
-    }
-}
-
-static void
 create_flag_buttons (BzPreferencesDialog *self)
 {
   GtkToggleButton *first_button = NULL;
@@ -212,18 +195,6 @@ bind_settings (BzPreferencesDialog *self)
   g_settings_bind (self->settings, "hide-eol",
                    self->hide_eol_switch, "active",
                    G_SETTINGS_BIND_DEFAULT);
-
-  g_settings_bind (self->settings, "rotate-flag",
-                 self->rotate_switch, "active",
-                 G_SETTINGS_BIND_DEFAULT);
-
-  if (adw_switch_row_get_active (self->rotate_switch))
-    {
-      for (guint i = 0; i < G_N_ELEMENTS (bar_themes); i++)
-        {
-          gtk_widget_add_css_class (GTK_WIDGET (self->flag_buttons[i]), "horizontal");
-        }
-    }
 
   g_signal_connect_object (
       self->settings,
@@ -299,9 +270,7 @@ bz_preferences_dialog_class_init (BzPreferencesDialogClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, search_debounce_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, flag_buttons_box);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, hide_eol_switch);
-  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, rotate_switch);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
-  gtk_widget_class_bind_template_callback (widget_class, on_rotate_switch_changed);
 }
 
 static void

--- a/src/bz-transact-icon.c
+++ b/src/bz-transact-icon.c
@@ -299,9 +299,6 @@ apply_state (BzTransactIcon *self)
               g_signal_connect_swapped (
                   self->settings, "changed::global-progress-bar-theme",
                   G_CALLBACK (pride_flag_changed), self);
-              g_signal_connect_swapped (
-                  self->settings, "changed::rotate-flag",
-                  G_CALLBACK (pride_flag_changed), self);
             }
         }
     }
@@ -402,10 +399,7 @@ ensure_draw_css (BzTransactIcon *self)
 {
   g_autoptr (GtkWidget) widget = NULL;
   g_autofree char *id          = NULL;
-  g_autofree char *final_id    = NULL;
   g_autofree char *class       = NULL;
-  gboolean         rotate      = FALSE;
-
   widget = bge_wdgt_renderer_lookup_object (self->wdgt, "flag");
 
   if (self->settings == NULL)
@@ -416,15 +410,8 @@ ensure_draw_css (BzTransactIcon *self)
       return;
     }
 
-  id     = g_settings_get_string (self->settings, "global-progress-bar-theme");
-  rotate = g_settings_get_boolean (self->settings, "rotate-flag");
-
-  if (rotate && g_strcmp0 (id, "accent-color") != 0)
-    final_id = g_strdup_printf ("%s-horizontal", id);
-  else
-    final_id = g_strdup (id);
-
-  class = bz_dup_css_class_for_pride_id (final_id);
+  id    = g_settings_get_string (self->settings, "global-progress-bar-theme");
+  class = bz_dup_css_class_for_pride_id (id);
 
   if (self->pride_class != NULL &&
       g_strcmp0 (self->pride_class, class) == 0)


### PR DESCRIPTION
Changed it so the install controls always use the horizontal variants, as flags with many colours look better on the long pill. And vertical for the transact icon.