### PR TITLE
Only show "Links" label when add-ons are shown

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -650,12 +650,19 @@ template $BzFullView: Adw.Bin {
                             orientation: vertical;
 
                             Label {
-                              styles ["heading"]
                               halign: start;
                               label: _("Links");
                               margin-top: 5;
                               margin-bottom: 8;
                               margin-start: 3;
+                              visible: bind $logical_and(
+                                  $invert_boolean($is_empty(template.ui-entry as <$BzResult>.object as <$BzEntry>.share-urls) as <bool>) as <bool>,
+                                  $invert_boolean($is_zero(addon_model.n-items) as <int>) as <bool>
+                                ) as <bool>;
+
+                              styles [
+                                "heading",
+                              ]
                             }
 
                             $BzShareList {


### PR DESCRIPTION
<img width="1968" height="1856" alt="Screenshot From 2026-05-27 18-34-25" src="https://github.com/user-attachments/assets/da1f6da6-7cdb-435f-bfec-2776128fbec2" />
<img width="1968" height="1856" alt="Screenshot From 2026-05-27 18-33-52" src="https://github.com/user-attachments/assets/4db6602a-1029-4f99-8f27-e625d7b5e768" />
