### PR TITLE
Make the installed donation button have its link as its tooltip

### DIFF
--- a/src/bz-installed-tile.blp
+++ b/src/bz-installed-tile.blp
@@ -66,7 +66,7 @@ template $BzInstalledTile: $BzListTile {
       ]
 
       has-tooltip: true;
-      tooltip-text: _("Support This Application");
+      tooltip-text: bind template.group as <$BzEntryGroup>.donation-url;
 
       width-request: 32;
       height-request: 32;


### PR DESCRIPTION
This makes it more obvious that the button will open a URL, it also follows the pattern of the other donation button in the full view.