### PR TITLE
flatpak-instance: detect user-installed flathub remote

### DIFF
--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -842,8 +842,6 @@ check_has_flathub_fiber (CheckHasFlathubData *data)
       n_system_remotes = system_remotes->len;
     }
 
-// Downloading from user remotes in the Flatpak is unsupported.
-#ifndef SANDBOXED_LIBFLATPAK
   if (self->user != NULL)
     {
       user_remotes = flatpak_installation_list_remotes (
@@ -856,7 +854,6 @@ check_has_flathub_fiber (CheckHasFlathubData *data)
             local_error->message);
       n_user_remotes = user_remotes->len;
     }
-#endif
 
   for (guint i = 0; i < n_system_remotes + n_user_remotes; i++)
     {
@@ -893,16 +890,6 @@ ensure_flathub_fiber (EnsureFlathubData *data)
 
 #define REPO_URL "https://dl.flathub.org/repo/flathub.flatpakrepo"
 
-#ifdef SANDBOXED_LIBFLATPAK
-  if (self->system != NULL)
-    {
-      remote = flatpak_installation_get_remote_by_name (
-          self->system, "flathub", cancellable, NULL);
-      installation = self->system;
-    }
-  if (remote == NULL)
-    return dex_future_new_true ();
-#else
   if (self->user != NULL)
     {
       remote = flatpak_installation_get_remote_by_name (
@@ -916,7 +903,6 @@ ensure_flathub_fiber (EnsureFlathubData *data)
       if (remote != NULL)
         installation = self->system;
     }
-#endif
 
   if (remote != NULL)
     {


### PR DESCRIPTION
## Summary
- `check_has_flathub_fiber` skipped user remotes under `SANDBOXED_LIBFLATPAK`, so a user-installed `flathub` was invisible to Bazaar — the "empty page" / no-categories state stuck even when Flathub was actually configured.
- `ensure_flathub_fiber` had a parallel sandbox branch that returned success without doing anything when the system Flathub was missing, silently no-op'ing the "Set Up Flathub" action and re-prompting on every launch.
- Drop both `#ifdef SANDBOXED_LIBFLATPAK` guards so the unified user-then-system path is used in both builds.

## Test plan
- [ ] `SANDBOXED_LIBFLATPAK` build with only a *user* Flathub remote: launch and confirm categories populate (no empty-page state).
- [ ] `SANDBOXED_LIBFLATPAK` build with no Flathub anywhere: clicking "Set Up Flathub" in the prompt actually adds Flathub (no silent no-op, prompt does not return on next launch).
- [ ] Non-`SANDBOXED_LIBFLATPAK` build: behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)