### PR TITLE
Have less padding for install controls on mobile

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -420,15 +420,15 @@ template $BzFullView: Adw.Bin {
                             };
                           }
                         }
-                      }
-
-                      $BzInstallControls narrow_install_controls {
-                        wide: false;
-                        visible: false;
-                        entry-group: bind template.entry-group as <$BzEntryGroup>;
-                        state: bind template.state as <$BzStateInfo>;
-                        settings: bind template.state as <$BzStateInfo>.settings;
-                        update => $update_cb(template);
+                        $BzInstallControls narrow_install_controls {
+                          wide: false;
+                          visible: false;
+                          margin-top: 6;
+                          entry-group: bind template.entry-group as <$BzEntryGroup>;
+                          state: bind template.state as <$BzStateInfo>;
+                          settings: bind template.state as <$BzStateInfo>.settings;
+                          update => $update_cb(template);
+                        }
                       }
 
                       Box {

--- a/src/bz-install-controls.blp
+++ b/src/bz-install-controls.blp
@@ -4,7 +4,8 @@ using Adw 1;
 template $BzInstallControls: Box {
   hexpand: bind $invert_boolean(template.wide) as <bool>;
 
-  Stack {
+  Stack stack {
+    visible: bind $is_not_empty_page(stack.visible-child-name) as <bool>;
     transition-type: crossfade;
     visible-child-name: bind try {
                               $get_visible_page(template.entry-group as <$BzEntryGroup>.installable, template.entry-group as <$BzEntryGroup>.removable, template.state as <$BzStateInfo>.available-updates, template.tracker as <$BzTransactionEntryTracker>.active as <bool> ) as <string>,
@@ -19,8 +20,6 @@ template $BzInstallControls: Box {
       child: $BgeWdgtRenderer animated_button {
         margin-top: 3;
         margin-bottom: 3;
-        margin-start: 3;
-        margin-end: 3;
 
         resource: "/io/github/kolunmi/Bazaar/bz-install-controls.wdgt";
         reference: bind template.tracker as <$BzTransactionEntryTracker>;
@@ -49,9 +48,6 @@ template $BzInstallControls: Box {
 
         margin-top: 3;
         margin-bottom: 3;
-        margin-start: 3;
-        margin-end: 3;
-
         Button open_button {
           styles [
             "pill",
@@ -108,8 +104,6 @@ template $BzInstallControls: Box {
 
         margin-top: 3;
         margin-bottom: 3;
-        margin-start: 3;
-        margin-end: 3;
 
         Button update_button {
           styles [

--- a/src/bz-install-controls.c
+++ b/src/bz-install-controls.c
@@ -221,6 +221,16 @@ update_cb (BzInstallControls *self,
     g_signal_emit (self, signals[SIGNAL_UPDATE], 0, G_LIST_MODEL (store));
 }
 
+static gboolean
+is_not_empty_page (gpointer    object,
+                   const char *page_name)
+{
+  if (page_name == NULL)
+    return FALSE;
+
+  return g_strcmp0 (page_name, "empty") != 0;
+}
+
 static char *
 get_visible_page (gpointer    object,
                   int         installable,
@@ -539,6 +549,7 @@ bz_install_controls_class_init (BzInstallControlsClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, remove_cb);
   gtk_widget_class_bind_template_callback (widget_class, run_cb);
   gtk_widget_class_bind_template_callback (widget_class, update_cb);
+  gtk_widget_class_bind_template_callback (widget_class, is_not_empty_page);
   gtk_widget_class_bind_template_callback (widget_class, get_visible_page);
   gtk_widget_class_bind_template_callback (widget_class, get_install_btn_state);
   gtk_widget_class_bind_template_callback (widget_class, install_btn_state_fallback);


### PR DESCRIPTION
Also hides the widget on its empty state, so there isn't a giant gap when showing Bazaar on mobile.

<img width="452" height="810" alt="Screenshot From 2026-06-04 14-17-37" src="https://github.com/user-attachments/assets/d7991b89-6510-4d26-9bd6-a1115e28b4ba" />
<img width="451" height="810" alt="Screenshot From 2026-06-04 16-19-23" src="https://github.com/user-attachments/assets/c3de24c1-8e13-425c-a6fa-511d70aa90ea" />
