### PR TITLE
Add Mobile Search Filter & rework its "all apps page"

### DIFF
--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -609,6 +609,9 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
         }
     }
 
+  if (is_mobile_friendly)
+    categories = bz_category_flags_add (categories, "mobile");
+
   if (g_strcmp0 (remote_name, "flathub") == 0)
     {
       const char *verified_str     = NULL;

--- a/src/bz-entry-group.c
+++ b/src/bz-entry-group.c
@@ -713,6 +713,13 @@ bz_entry_group_get_is_verified (BzEntryGroup *self)
   return self->is_verified;
 }
 
+gboolean
+bz_entry_group_get_is_mobile_friendly (BzEntryGroup *self)
+{
+  g_return_val_if_fail (BZ_IS_ENTRY_GROUP (self), FALSE);
+  return (self->categories & BZ_CATEGORY_FLAGS_MOBILE) != 0;
+}
+
 const char *
 bz_entry_group_get_search_tokens (BzEntryGroup *self)
 {

--- a/src/bz-entry-group.h
+++ b/src/bz-entry-group.h
@@ -76,6 +76,9 @@ bz_entry_group_get_is_flathub (BzEntryGroup *self);
 gboolean
 bz_entry_group_get_is_verified (BzEntryGroup *self);
 
+gboolean
+bz_entry_group_get_is_mobile_friendly (BzEntryGroup *self);
+
 const char *
 bz_entry_group_get_search_tokens (BzEntryGroup *self);
 

--- a/src/bz-flathub-state.c
+++ b/src/bz-flathub-state.c
@@ -730,7 +730,7 @@ initialize_fiber (GWeakRef *wr)
   ADD_REQUEST (added_f, "/collection/recently-added?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
   ADD_REQUEST (popular_f, "/collection/popular?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
   ADD_REQUEST (trending_f, "/collection/trending?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
-  ADD_REQUEST (mobile_f, "/collection/mobile?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
+  ADD_REQUEST (mobile_f, "/collection/mobile?page=0&per_page=%d", CATEGORY_FETCH_SIZE);
 
 #undef ADD_REQUEST
 

--- a/src/bz-search-filter-popover.blp
+++ b/src/bz-search-filter-popover.blp
@@ -28,7 +28,7 @@ template $BzSearchFilterPopover: Gtk.Popover {
         child-spacing: 6;
         line-spacing: 6;
         natural-line-length: 320;
-        justify-last-line: true;
+        justify-last-line: false;
 
         Button verified_button {
           name: "verified";
@@ -50,6 +50,13 @@ template $BzSearchFilterPopover: Gtk.Popover {
           clicked => $on_filter_button_clicked();
           use-underline: true;
           tooltip-text: _("Filter out End-of-Life apps");
+        }
+
+        Button mobile_button {
+          name: "mobile";
+          label: _("_Mobile Friendly");
+          clicked => $on_filter_button_clicked();
+          use-underline: true;
         }
       }
 

--- a/src/bz-search-filter-popover.c
+++ b/src/bz-search-filter-popover.c
@@ -37,6 +37,7 @@ struct _BzSearchFilterPopover
   gboolean        only_verified;
   gboolean        only_free;
   gboolean        only_non_eol;
+  gboolean        only_mobile;
   gboolean        has_active_filters;
   gboolean        state_forced_verified;
   gboolean        state_forced_free;
@@ -46,6 +47,7 @@ struct _BzSearchFilterPopover
   GtkWidget  *verified_button;
   GtkWidget  *free_button;
   GtkWidget  *non_eol_button;
+  GtkWidget  *mobile_button;
 };
 
 G_DEFINE_FINAL_TYPE (BzSearchFilterPopover, bz_search_filter_popover, GTK_TYPE_POPOVER)
@@ -57,6 +59,7 @@ enum
   PROP_ONLY_VERIFIED,
   PROP_ONLY_FREE,
   PROP_ONLY_NON_EOL,
+  PROP_ONLY_MOBILE,
   PROP_HAS_ACTIVE_FILTERS,
   LAST_PROP
 };
@@ -116,6 +119,9 @@ bz_search_filter_popover_get_property (GObject    *object,
     case PROP_ONLY_NON_EOL:
       g_value_set_boolean (value, self->only_non_eol);
       break;
+    case PROP_ONLY_MOBILE:
+      g_value_set_boolean (value, self->only_mobile);
+      break;
     case PROP_HAS_ACTIVE_FILTERS:
       g_value_set_boolean (value, self->has_active_filters);
       break;
@@ -165,6 +171,13 @@ bz_search_filter_popover_class_init (BzSearchFilterPopoverClass *klass)
           FALSE,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
+  props[PROP_ONLY_MOBILE] =
+      g_param_spec_boolean (
+          "only-mobile",
+          NULL, NULL,
+          FALSE,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
   props[PROP_HAS_ACTIVE_FILTERS] =
       g_param_spec_boolean (
           "has-active-filters",
@@ -179,6 +192,7 @@ bz_search_filter_popover_class_init (BzSearchFilterPopoverClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzSearchFilterPopover, verified_button);
   gtk_widget_class_bind_template_child (widget_class, BzSearchFilterPopover, free_button);
   gtk_widget_class_bind_template_child (widget_class, BzSearchFilterPopover, non_eol_button);
+  gtk_widget_class_bind_template_child (widget_class, BzSearchFilterPopover, mobile_button);
   gtk_widget_class_bind_template_callback (widget_class, on_filter_button_clicked);
 }
 
@@ -237,6 +251,13 @@ bz_search_filter_popover_get_only_non_eol (BzSearchFilterPopover *self)
   return self->only_non_eol;
 }
 
+gboolean
+bz_search_filter_popover_get_only_mobile (BzSearchFilterPopover *self)
+{
+  g_return_val_if_fail (BZ_IS_SEARCH_FILTER_POPOVER (self), FALSE);
+  return self->only_mobile;
+}
+
 void
 bz_search_filter_popover_clear (BzSearchFilterPopover *self)
 {
@@ -250,6 +271,7 @@ bz_search_filter_popover_clear (BzSearchFilterPopover *self)
     apply_filter_button (self, PROP_ONLY_FREE, FALSE);
   if (!self->state_forced_non_eol)
     apply_filter_button (self, PROP_ONLY_NON_EOL, FALSE);
+  apply_filter_button (self, PROP_ONLY_MOBILE, FALSE);
 
   for (child = gtk_widget_get_first_child (GTK_WIDGET (self->wrap_box));
        child != NULL;
@@ -272,6 +294,7 @@ update_has_active_filters (BzSearchFilterPopover *self)
   active = (self->only_verified && !self->state_forced_verified) ||
            (self->only_free && !self->state_forced_free) ||
            (self->only_non_eol && !self->state_forced_non_eol) ||
+           self->only_mobile ||
            self->selected_categories != BZ_CATEGORY_FLAGS_NONE;
 
   if (self->has_active_filters == active)
@@ -295,6 +318,7 @@ apply_filter_button (BzSearchFilterPopover *self,
     { PROP_ONLY_VERIFIED, &self->only_verified, &self->verified_button },
     {     PROP_ONLY_FREE,     &self->only_free,     &self->free_button },
     {  PROP_ONLY_NON_EOL,  &self->only_non_eol,  &self->non_eol_button },
+    {   PROP_ONLY_MOBILE,   &self->only_mobile,   &self->mobile_button },
   };
 
   for (guint i = 0; i < G_N_ELEMENTS (map); i++)
@@ -398,6 +422,8 @@ on_filter_button_clicked (GtkButton *button,
     apply_filter_button (self, PROP_ONLY_FREE, !self->only_free);
   else if (g_str_equal (name, "non-eol"))
     apply_filter_button (self, PROP_ONLY_NON_EOL, !self->only_non_eol);
+  else if (g_str_equal (name, "mobile"))
+    apply_filter_button (self, PROP_ONLY_MOBILE, !self->only_mobile);
 }
 
 static void

--- a/src/bz-search-filter-popover.h
+++ b/src/bz-search-filter-popover.h
@@ -42,6 +42,9 @@ bz_search_filter_popover_get_only_free (BzSearchFilterPopover *self);
 gboolean
 bz_search_filter_popover_get_only_non_eol (BzSearchFilterPopover *self);
 
+gboolean
+bz_search_filter_popover_get_only_mobile (BzSearchFilterPopover *self);
+
 void
 bz_search_filter_popover_clear (BzSearchFilterPopover *self);
 

--- a/src/bz-search-page.c
+++ b/src/bz-search-page.c
@@ -471,6 +471,8 @@ bz_search_page_init (BzSearchPage *self)
                             G_CALLBACK (update_filter), self);
   g_signal_connect_swapped (self->filter_popover, "notify::only-non-eol",
                             G_CALLBACK (update_filter), self);
+  g_signal_connect_swapped (self->filter_popover, "notify::only-mobile",
+                            G_CALLBACK (update_filter), self);
 }
 
 GtkWidget *
@@ -717,6 +719,7 @@ search_query_then (DexFuture *future,
   gboolean               only_verified = FALSE;
   gboolean               only_free     = FALSE;
   gboolean               only_non_eol  = FALSE;
+  gboolean               only_mobile   = FALSE;
 
   bz_weak_get_or_return_reject (self, wr);
 
@@ -726,6 +729,7 @@ search_query_then (DexFuture *future,
   only_verified = bz_search_filter_popover_get_only_verified (self->filter_popover);
   only_free     = bz_search_filter_popover_get_only_free (self->filter_popover);
   only_non_eol  = bz_search_filter_popover_get_only_non_eol (self->filter_popover);
+  only_mobile   = bz_search_filter_popover_get_only_mobile (self->filter_popover);
 
   filtered = g_ptr_array_new_with_free_func (g_object_unref);
 
@@ -749,6 +753,9 @@ search_query_then (DexFuture *future,
         continue;
 
       if (only_non_eol && bz_entry_group_get_eol (group))
+        continue;
+
+      if (only_mobile && !bz_entry_group_get_is_mobile_friendly (group))
         continue;
 
       g_ptr_array_add (filtered, g_object_ref (result));


### PR DESCRIPTION
Whilst we can't add a toggle in preferences to filter out not mobile apps globally due to the UI issue, we can add it to search without a problem.

Instead of adding a new bool property to entry group, I opted to just set the mobile category flag (that already existed) and consume that instead.

This also means that we can trivially convert its "all apps page" to actually show all mobile apps instead of just showing the collection overflow, like we do with "popular" and such.

<img width="2370" height="1718" alt="Screenshot From 2026-06-06 20-47-40" src="https://github.com/user-attachments/assets/ffb7a392-a27b-4aba-a426-90afc35baf52" />

Closes #1591