### PR TITLE
Fix infinite fetching of user data folder size

### DIFF
--- a/src/bz-entry-group.c
+++ b/src/bz-entry-group.c
@@ -1573,9 +1573,10 @@ user_data_size_then (DexFuture *future,
   g_autoptr (BzEntryGroup) self  = NULL;
   g_autoptr (GError) error       = NULL;
   g_autoptr (BzSizeResult) sizes = NULL;
+  guint64 new_user_data_size     = 0;
+  guint64 new_cache_size         = 0;
 
   bz_weak_get_or_return_reject (self, wr);
-  dex_clear (&self->user_data_size_future);
 
   sizes = g_value_dup_object (dex_future_get_value (future, &error));
   if (error != NULL || sizes == NULL)
@@ -1584,11 +1585,20 @@ user_data_size_then (DexFuture *future,
       return dex_future_new_true ();
     }
 
-  self->user_data_size = bz_size_result_get_user_data_size (sizes);
-  self->cache_size     = bz_size_result_get_cache_size (sizes);
+  new_user_data_size = bz_size_result_get_user_data_size (sizes);
+  new_cache_size     = bz_size_result_get_cache_size (sizes);
 
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_USER_DATA_SIZE]);
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CACHE_SIZE]);
+  if (new_user_data_size != self->user_data_size)
+    {
+      self->user_data_size = new_user_data_size;
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_USER_DATA_SIZE]);
+    }
+
+  if (new_cache_size != self->cache_size)
+    {
+      self->cache_size = new_cache_size;
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CACHE_SIZE]);
+    }
 
   return dex_future_new_true ();
 }


### PR DESCRIPTION
This infinite loop caused CPU usage to spike, and probably disk access too, especially for installed apps with large user data or cache directories, like web browsers.

Fixes #1594 

This probably also fixes this issue:
Fixes #1507