### PR TITLE
Fix double focus on the rich card

### DIFF
--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -274,6 +274,7 @@ template $BzSearchPage: Adw.Bin {
 
                   factory: BuilderListItemFactory {
                     template ListItem {
+                      focusable: false;
                       child: Box {
                         orientation: vertical;
                         spacing: 5;


### PR DESCRIPTION
You would need to press tab twice before going to the next element.