### PR TITLE
search-page: Fix needing to double press TAB app tiles

### DIFF
--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -275,6 +275,8 @@ template $BzSearchPage: Adw.Bin {
 
                   factory: BuilderListItemFactory {
                     template ListItem {
+                      focusable: false;
+
                       child: Box {
                         orientation: vertical;
                         spacing: 5;


### PR DESCRIPTION
Pressing TAB would first focus the ListItemWidget, then the app tile, then the app remove/install button, then the next ListItemWidget - to make it easier to TAB through the app tiles, set the ListItemWidget to not be focusable, so it only requires 2 TABs to cycle through an app tile, instead of 3

Before:

https://github.com/user-attachments/assets/08d562d1-8731-43dd-9014-27b462a18284

After:

https://github.com/user-attachments/assets/624673da-1354-424e-ac70-ad6e1d5be1a9


