### PR TITLE
Share a global thread pool scheduler

### DIFF
--- a/src/bz-entry-cache-manager.c
+++ b/src/bz-entry-cache-manager.c
@@ -225,7 +225,8 @@ bz_entry_cache_manager_init (BzEntryCacheManager *self)
 {
   g_mutex_init (&self->mutex);
 
-  self->scheduler = dex_thread_pool_scheduler_new ();
+  // self->scheduler = dex_thread_pool_scheduler_new ();
+  self->scheduler = dex_ref (dex_thread_pool_scheduler_get_default ());
 
   self->init       = dex_promise_new ();
   self->alive_hash = g_hash_table_new_full (

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -403,7 +403,9 @@ bz_flatpak_instance_class_init (BzFlatpakInstanceClass *klass)
 static void
 bz_flatpak_instance_init (BzFlatpakInstance *self)
 {
-  self->scheduler   = dex_thread_pool_scheduler_new ();
+  // self->scheduler   = dex_thread_pool_scheduler_new ();
+  self->scheduler = dex_ref (dex_thread_pool_scheduler_get_default ());
+
   self->system_mute = 0;
   self->user_mute   = 0;
 

--- a/src/bz-io.c
+++ b/src/bz-io.c
@@ -53,12 +53,14 @@ bz_dup_user_cache_path (const char *app_id)
 DexScheduler *
 bz_get_io_scheduler (void)
 {
-  static DexScheduler *scheduler = NULL;
+  // static DexScheduler *scheduler = NULL;
+  //
+  // if (g_once_init_enter_pointer (&scheduler))
+  //   g_once_init_leave_pointer (&scheduler, dex_thread_pool_scheduler_new ());
+  //
+  // return scheduler;
 
-  if (g_once_init_enter_pointer (&scheduler))
-    g_once_init_leave_pointer (&scheduler, dex_thread_pool_scheduler_new ());
-
-  return scheduler;
+  return dex_thread_pool_scheduler_get_default ();
 }
 
 void


### PR DESCRIPTION
I'm not sure if having separate instances of this resource is necessary for performance. In doing this, we might give libdex more of a chance to better manage its threads