### PR TITLE
Disable the focus on the rich app tile instead of the list item

### DIFF
--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -274,13 +274,14 @@ template $BzSearchPage: Adw.Bin {
 
                   factory: BuilderListItemFactory {
                     template ListItem {
-                      focusable: false;
+
                       child: Box {
                         orientation: vertical;
                         spacing: 5;
 
                         $BzRichAppTile {
                           group: bind template.item as <$BzSearchResult>.group as <$BzEntryGroup>;
+                          focusable: false;
                           activated => $tile_activated_cb(template);
                         }
 


### PR DESCRIPTION
Our previous approach stopped the arrow navigation from working