### PR TITLE
Disable the focus on the rich app tile instead of the list item

### DIFF
--- a/src/bz-list-tile.c
+++ b/src/bz-list-tile.c
@@ -242,10 +242,6 @@ on_gesture_click_released (BzListTile      *self,
   if (gtk_widget_contains (GTK_WIDGET (self), x, y))
     {
       gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
-
-      if (!gtk_widget_grab_focus (GTK_WIDGET (self)))
-        g_assert_not_reached ();
-
       g_signal_emit (self, signals[ACTIVATED], 0);
     }
   else

--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -274,13 +274,14 @@ template $BzSearchPage: Adw.Bin {
 
                   factory: BuilderListItemFactory {
                     template ListItem {
-                      focusable: false;
+
                       child: Box {
                         orientation: vertical;
                         spacing: 5;
 
                         $BzRichAppTile {
                           group: bind template.item as <$BzSearchResult>.group as <$BzEntryGroup>;
+                          focusable: false;
                           activated => $tile_activated_cb(template);
                         }
 


### PR DESCRIPTION
Our previous approach stopped the arrow navigation from working