### PR TITLE
Redesign license dialog

### DIFF
--- a/src/bz-license-dialog.blp
+++ b/src/bz-license-dialog.blp
@@ -2,7 +2,6 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzLicenseDialog: Adw.Bin {
-
   child: Adw.ToolbarView {
     [top]
     Adw.HeaderBar {
@@ -21,7 +20,7 @@ template $BzLicenseDialog: Adw.Bin {
 
         Box {
           orientation: vertical;
-          margin-bottom: 24;
+          margin-bottom: 16;
           valign: center;
           vexpand: true;
 
@@ -54,66 +53,74 @@ template $BzLicenseDialog: Adw.Bin {
 
         Box {
           orientation: vertical;
-          spacing: 12;
+          spacing: 6;
+          margin-bottom: 12;
 
-          ListBox {
-            selection-mode: none;
+          Label {
+            label: bind $get_license_info(template.entry as <$BzEntry>) as <string>;
+            valign: start;
+            margin-bottom: 18;
+            margin-start: 18;
+            margin-end: 18;
+            use-markup: true;
+            xalign: 0.50;
+            wrap: true;
+            wrap-mode: word_char;
+            justify: center;
+          }
 
+          Button {
             styles [
-              "boxed-list",
+              "pill",
             ]
 
-            ListBoxRow {
-              vexpand: true;
-              activatable: false;
+            visible: bind template.entry as <$BzEntry>.is-floss as <bool>;
+            clicked => $contribute_cb(template);
+            tooltip-text: bind $get_involved_tooltip(template.entry) as <string>;
+            halign: center;
+
+            child: Box {
+              orientation: horizontal;
+              spacing: 10;
 
               Label {
-                label: bind $get_license_info(template.entry as <$BzEntry>) as <string>;
-                valign: start;
-                margin-top: 12;
-                margin-bottom: 12;
-                margin-start: 12;
-                margin-end: 12;
-                use-markup: true;
-                xalign: 0;
+                label: _("Get Involved");
                 wrap: true;
                 wrap-mode: word_char;
+                justify: right;
               }
-            }
+
+              Image {
+                icon-name: "external-link-symbolic";
+              }
+            };
           }
 
-          ListBox {
-            visible: bind template.entry as <$BzEntry>.is-floss as <bool>;
-            selection-mode: none;
-
+          Button {
             styles [
-              "boxed-list",
+              "pill",
             ]
 
-            Adw.ButtonRow {
-              title: _("Get Involved");
-              end-icon-name: "external-link-symbolic";
-              activated => $contribute_cb(template);
-              has-tooltip: true;
-              tooltip-text: bind $get_involved_tooltip(template.entry) as <string>;
-            }
-          }
-
-          ListBox {
             visible: bind $should_show_eula(template.entry as <$BzEntry>) as <bool>;
-            selection-mode: none;
+            clicked => $eula_cb(template);
+            tooltip-text: bind $eula_tooltip(template.entry) as <string>;
+            halign: center;
 
-            styles [
-              "boxed-list",
-            ]
+            child: Box {
+              orientation: horizontal;
+              spacing: 10;
 
-            Adw.ButtonRow {
-              title: _("Learn More");
-              end-icon-name: "external-link-symbolic";
-              activated => $eula_cb(template);
-              has-tooltip: true;
-              tooltip-text: bind $eula_tooltip(template.entry) as <string>;
-            }
+              Label {
+                label: _("Learn More");
+                wrap: true;
+                wrap-mode: word_char;
+                justify: right;
+              }
+
+              Image {
+                icon-name: "external-link-symbolic";
+              }
+            };
           }
         }
       };

--- a/src/bz-license-dialog.c
+++ b/src/bz-license-dialog.c
@@ -340,7 +340,7 @@ bz_license_dialog_new (BzEntry *entry)
   widget = g_object_new (BZ_TYPE_LICENSE_DIALOG, "entry", entry, NULL);
 
   dialog = adw_dialog_new ();
-  adw_dialog_set_content_width (dialog, 400);
+  adw_dialog_set_content_width (dialog, 425);
   adw_dialog_set_child (dialog, GTK_WIDGET (widget));
 
   return dialog;


### PR DESCRIPTION
I have tried to follow previously used patterns, such as those seen with Adw.StatusPage and the donate dialog.

<img width="1736" height="1758" alt="Screenshot From 2026-06-13 15-25-55" src="https://github.com/user-attachments/assets/c9a4902d-fdb2-4bc1-b5c2-750d6f9fb1f1" />
<img width="1736" height="1758" alt="Screenshot From 2026-06-13 15-25-49" src="https://github.com/user-attachments/assets/55ac3983-0da8-481b-b0e9-243203cc61d9" />
