### PR TITLE
Better handle slow entry decaches in UI

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -37,6 +37,12 @@ template $BzFullView: Adw.Bin {
       }
 
       Adw.ViewStackPage {
+        name: "loading";
+        title: _("Empty");
+        child: Adw.Bin {};
+      }
+
+      Adw.ViewStackPage {
         name: "content";
         title: _("Content");
 
@@ -95,12 +101,6 @@ template $BzFullView: Adw.Bin {
                   vexpand: false;
                   margin-bottom: 15;
                   spacing: 20;
-
-                  // Adw.Banner {
-                  //   title: _("Installing .flatpak bundles is not yet supported");
-                  //   visible: bind template.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.is-bundle as <bool>;
-                  //   revealed: true;
-                  // }
 
                   Adw.Banner {
                     title: _("This is a local preview, some details may differ from the published listing");
@@ -469,21 +469,14 @@ template $BzFullView: Adw.Bin {
                     };
                   }
 
-                  Box screenshot_box {
-                    Adw.Spinner {
-                      vexpand: true;
-                      visible: bind $invert_boolean(template.ui-entry as <$BzResult>.resolved as <bool>) as <bool>;
-                    }
+                  $BzScreenshotsCarousel screenshots {
+                    vexpand: true;
+                    hexpand: true;
+                    clicked => $screenshot_clicked_cb() swapped;
+                    light-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.light-accent-color;
+                    dark-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.dark-accent-color;
 
-                    $BzScreenshotsCarousel screenshots {
-                      vexpand: true;
-                      hexpand: true;
-                      clicked => $screenshot_clicked_cb() swapped;
-                      light-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.light-accent-color;
-                      dark-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.dark-accent-color;
-
-                      model: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.screenshot-paintables;
-                    }
+                    model: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.screenshot-paintables;
                   }
 
                   Adw.Clamp {

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -855,6 +855,8 @@ on_ui_entry_resolved (DexFuture *future,
         self->runtime = bz_flatpak_entry_dup_runtime_result (BZ_FLATPAK_ENTRY (ui_entry));
     }
 
+  adw_view_stack_set_visible_child_name (self->stack, "content");
+
   return dex_future_new_for_boolean (TRUE);
 }
 
@@ -912,6 +914,8 @@ bz_full_view_set_entry_group (BzFullView   *self,
             {
               g_autoptr (DexFuture) ui_future = NULL;
 
+              adw_view_stack_set_visible_child_name (self->stack, "loading");
+
               ui_future = bz_result_dup_future (self->ui_entry);
               ui_future = dex_future_then (
                   ui_future,
@@ -921,8 +925,6 @@ bz_full_view_set_entry_group (BzFullView   *self,
               self->ui_future = g_steal_pointer (&ui_future);
             }
         }
-
-      adw_view_stack_set_visible_child_name (self->stack, "content");
     }
   else
     adw_view_stack_set_visible_child_name (self->stack, "empty");

--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -36,10 +36,10 @@ template $BzRichAppTile: $BzListTile {
           valign: center;
           hexpand: true;
 
-          visible: bind $is_null(template.ui-entry as <$BzEntry>.thumbnail-paintable) as <bool>;
+          visible: bind screenshot.visible inverted;
         }
 
-        $BzRoundedPicture {
+        $BzRoundedPicture screenshot {
           halign: center;
           hexpand: true;
           valign: center;


### PR DESCRIPTION
Added a widgetless "loading" screen for the full view in the rare circumstance where the entry is not loaded instantly, masking the broken state the full view shows when no entry is available.

Also prevents both the unloaded screenshot and the "no image" icon from being shown next to each other when an entry has not yet been deserialized.