### PR TITLE
Focus the first install or remove button when pressing enter in search bar

### DIFF
--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -146,7 +146,7 @@ template $BzRichAppTile: $BzListTile {
         }
       }
 
-      Stack {
+      Stack action_stack {
         transition-type: crossfade;
         valign: center;
         hhomogeneous: false;

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -42,6 +42,7 @@ struct _BzRichAppTile
   GtkWidget          *picture_box;
   GtkWidget          *get_button;
   BzTransactIconInfo *transact_icon_info;
+  GtkWidget          *action_stack;
 };
 
 G_DEFINE_FINAL_TYPE (BzRichAppTile, bz_rich_app_tile, BZ_TYPE_LIST_TILE);
@@ -352,6 +353,7 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, picture_box);
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, get_button);
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, transact_icon_info);
+  gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, action_stack);
 
   gtk_widget_class_set_accessible_role (widget_class, GTK_ACCESSIBLE_ROLE_BUTTON);
 }
@@ -444,4 +446,17 @@ bz_rich_app_tile_set_group (BzRichAppTile *self,
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_GROUP]);
 }
+
+void
+bz_rich_app_tile_focus_action_button (BzRichAppTile *self)
+{
+  GtkWidget *visible_child = NULL;
+
+  g_return_if_fail (BZ_IS_RICH_APP_TILE (self));
+
+  visible_child = gtk_stack_get_visible_child (GTK_STACK (self->action_stack));
+  if (visible_child != NULL)
+    gtk_widget_grab_focus (visible_child);
+}
+
 /* End of bz-rich-app-tile.c */

--- a/src/bz-rich-app-tile.h
+++ b/src/bz-rich-app-tile.h
@@ -42,5 +42,8 @@ void
 bz_rich_app_tile_set_group (BzRichAppTile *self,
                             BzEntryGroup  *group);
 
+void
+bz_rich_app_tile_focus_action_button (BzRichAppTile *self);
+
 G_END_DECLS
 /* End of bz-rich-app-tile.h */

--- a/src/bz-search-page.c
+++ b/src/bz-search-page.c
@@ -647,10 +647,8 @@ static void
 search_activate (GtkText      *text,
                  BzSearchPage *self)
 {
-  GtkSelectionModel *model          = NULL;
-  guint              n_items        = 0;
-  g_autoptr (BzSearchResult) result = NULL;
-  BzEntryGroup *group               = NULL;
+  GtkSelectionModel *model   = NULL;
+  guint              n_items = 0;
 
   model   = gtk_grid_view_get_model (self->grid_view);
   n_items = g_list_model_get_n_items (G_LIST_MODEL (model));
@@ -660,19 +658,20 @@ search_activate (GtkText      *text,
 
   if (n_items > 0)
     {
-      result = g_list_model_get_item (G_LIST_MODEL (model), 0);
-      group  = bz_search_result_get_group (result);
+      GtkWidget *cell = NULL;
+      GtkWidget *box  = NULL;
+      GtkWidget *tile = NULL;
 
-      if (bz_entry_group_get_removable_and_available (group) > 0)
-        {
-          gtk_widget_activate_action (GTK_WIDGET (self), "window.remove-group", "(sb)",
-                                      bz_entry_group_get_id (group), FALSE);
-        }
-      else if (bz_entry_group_get_installable_and_available (group) > 0)
-        {
-          gtk_widget_activate_action (GTK_WIDGET (self), "window.install-group", "(sb)",
-                                      bz_entry_group_get_id (group), FALSE);
-        }
+      gtk_widget_activate_action (GTK_WIDGET (self->grid_view), "list.scroll-to-item", "u", 0);
+
+      cell = gtk_widget_get_first_child (GTK_WIDGET (self->grid_view));
+      if (cell != NULL)
+        box = gtk_widget_get_first_child (cell);
+      if (box != NULL)
+        tile = gtk_widget_get_first_child (box);
+
+      if (BZ_IS_RICH_APP_TILE (tile))
+        bz_rich_app_tile_focus_action_button (BZ_RICH_APP_TILE (tile));
     }
 }
 


### PR DESCRIPTION
The idea is that people who want to press Enter twice to install an app can still do that, while not annoying people with muscle memory by triggering a dialog they didn't intend.

Closes #1595 