### PR TITLE
Make important full view text selectable

### DIFF
--- a/src/bz-appstream-description-render.blp
+++ b/src/bz-appstream-description-render.blp
@@ -6,6 +6,7 @@ template $BzAppstreamDescriptionRender: Adw.Bin {
     orientation: vertical;
 
     TextView text_view {
+      notify::has-focus => $text_focus_cb();
       editable: false;
       cursor-visible: false;
       wrap-mode: word_char;

--- a/src/bz-appstream-description-render.c
+++ b/src/bz-appstream-description-render.c
@@ -107,6 +107,10 @@ on_motion (GtkEventControllerMotion *controller,
            GtkTextView              *text_view);
 
 static void
+text_focus_cb (GtkTextView                  *text_view,
+               GParamSpec                   *pspec,
+               BzAppstreamDescriptionRender *self);
+static void
 bz_appstream_description_render_dispose (GObject *object)
 {
   BzAppstreamDescriptionRender *self = BZ_APPSTREAM_DESCRIPTION_RENDER (object);
@@ -172,6 +176,7 @@ bz_appstream_description_render_class_init (BzAppstreamDescriptionRenderClass *k
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-appstream-description-render.ui");
   gtk_widget_class_bind_template_child (widget_class, BzAppstreamDescriptionRender, text_view);
+  gtk_widget_class_bind_template_callback (widget_class, text_focus_cb);
 }
 
 static void
@@ -292,6 +297,25 @@ on_motion (GtkEventControllerMotion *controller,
     gtk_widget_set_cursor_from_name (GTK_WIDGET (text_view), "pointer");
   else
     gtk_widget_set_cursor (GTK_WIDGET (text_view), NULL);
+}
+
+static void
+text_focus_cb (GtkTextView                  *text_view,
+               GParamSpec                   *pspec,
+               BzAppstreamDescriptionRender *self)
+{
+  GtkTextBuffer *buffer = NULL;
+  GtkTextIter    start  = { 0 };
+  GtkTextIter    end    = { 0 };
+
+  buffer = gtk_text_view_get_buffer (self->text_view);
+
+  gtk_text_buffer_get_bounds (buffer, &start, &end);
+
+  if (gtk_widget_has_focus (GTK_WIDGET (text_view)))
+      gtk_text_buffer_select_range (buffer, &start, &end);
+  else
+      gtk_text_buffer_place_cursor (buffer, &start);
 }
 
 BzAppstreamDescriptionRender *

--- a/src/bz-developer-badge.blp
+++ b/src/bz-developer-badge.blp
@@ -15,6 +15,7 @@ template $BzDeveloperBadge: Box {
     ellipsize: end;
     wrap-mode: word_char;
     natural-wrap-mode: word;
+    selectable: true;
 
     styles [
       "app-developer",

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -174,6 +174,7 @@ template $BzFullView: Adw.Bin {
                               ellipsize: end;
                               wrap-mode: word_char;
                               natural-wrap-mode: word;
+                              selectable: true;
                               label: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.title;
                             }
 
@@ -554,6 +555,7 @@ template $BzFullView: Adw.Bin {
                             xalign: 0;
                             wrap: true;
                             wrap-mode: word_char;
+                            selectable: true;
                             label: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.description;
                           }
 

--- a/src/bz-releases-list.c
+++ b/src/bz-releases-list.c
@@ -250,6 +250,7 @@ create_release_row (const char *version,
 
       fallback_label = GTK_LABEL (gtk_label_new (_ ("No details for this release")));
       gtk_widget_set_margin_top (GTK_WIDGET (fallback_label), 5);
+      gtk_label_set_selectable (fallback_label, TRUE);
       gtk_widget_add_css_class (GTK_WIDGET (fallback_label), "dim-label");
       gtk_label_set_xalign (fallback_label, 0.0);
       gtk_label_set_wrap (fallback_label, TRUE);


### PR DESCRIPTION
This is needed for accessibility, it also includes a fix for the selected state of the description renderer, so it selects text like a normal label would do.