### PR TITLE
Trigger show-group action from app tiles directly

### DIFF
--- a/src/bz-all-apps-page.blp
+++ b/src/bz-all-apps-page.blp
@@ -35,7 +35,6 @@ template $BzAllAppsPage: Adw.NavigationPage {
               template ListItem {
                 child: $BzAppTile {
                   group: bind template.item as <$BzEntryGroup>;
-                  clicked => $tile_clicked_cb(template);
                 };
               }
             };

--- a/src/bz-all-apps-page.c
+++ b/src/bz-all-apps-page.c
@@ -49,10 +49,6 @@ enum
 static GParamSpec *props[LAST_PROP] = { 0 };
 
 static void
-tile_clicked_cb (GtkListItem *list_item,
-                 BzAppTile   *tile);
-
-static void
 bz_all_apps_page_dispose (GObject *object)
 {
   BzAllAppsPage *self = BZ_ALL_APPS_PAGE (object);
@@ -136,7 +132,6 @@ bz_all_apps_page_class_init (BzAllAppsPageClass *klass)
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-all-apps-page.ui");
   gtk_widget_class_bind_template_child (widget_class, BzAllAppsPage, grid_view);
-  gtk_widget_class_bind_template_callback (widget_class, tile_clicked_cb);
 }
 
 static void
@@ -167,16 +162,3 @@ bz_all_apps_page_new (const char *title,
   return ADW_NAVIGATION_PAGE (apps_page);
 }
 
-static void
-tile_clicked_cb (GtkListItem *list_item,
-                 BzAppTile   *tile)
-{
-  BzEntryGroup *group = NULL;
-
-  group = gtk_list_item_get_item (list_item);
-  if (group == NULL)
-    return;
-
-  gtk_widget_activate_action (GTK_WIDGET (tile), "window.show-group", "s",
-                              bz_entry_group_get_id (group));
-}

--- a/src/bz-app-tile.c
+++ b/src/bz-app-tile.c
@@ -285,6 +285,14 @@ bz_app_tile_set_group (BzAppTile    *self,
   if (group != NULL)
     self->group = g_object_ref (group);
 
+  if (group != NULL)
+    {
+      gtk_actionable_set_action_name (GTK_ACTIONABLE (self), "window.show-group");
+      gtk_actionable_set_action_target (GTK_ACTIONABLE (self), "s", bz_entry_group_get_id (group));
+    }
+  else
+      gtk_actionable_set_action_name (GTK_ACTIONABLE (self), NULL);
+
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_GROUP]);
 }
 

--- a/src/bz-apps-page.blp
+++ b/src/bz-apps-page.blp
@@ -91,8 +91,6 @@ template $BzAppsPage: Adw.NavigationPage {
               child-type: "BzAppTile";
               child-prop: "group";
               model: bind template.applications;
-              bind-widget => $bind_widget_cb(template);
-              unbind-widget => $unbind_widget_cb(template);
             }
 
             Button {

--- a/src/bz-apps-page.c
+++ b/src/bz-apps-page.c
@@ -64,11 +64,6 @@ enum
 };
 static GParamSpec *props[LAST_PROP] = { 0 };
 
-
-static void
-tile_clicked (BzEntryGroup *group,
-              GtkButton    *button);
-
 static void
 bz_apps_page_dispose (GObject *object)
 {
@@ -153,24 +148,6 @@ bz_apps_page_set_property (GObject      *object,
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
-}
-
-static void
-bind_widget_cb (BzAppsPage        *self,
-                BzAppTile         *tile,
-                BzEntryGroup      *group,
-                BzDynamicListView *view)
-{
-  g_signal_connect_swapped (tile, "clicked", G_CALLBACK (tile_clicked), group);
-}
-
-static void
-unbind_widget_cb (BzAppsPage        *self,
-                  BzAppTile         *tile,
-                  BzEntryGroup      *group,
-                  BzDynamicListView *view)
-{
-  g_signal_handlers_disconnect_by_func (tile, G_CALLBACK (tile_clicked), group);
 }
 
 static gboolean
@@ -306,8 +283,6 @@ bz_apps_page_class_init (BzAppsPageClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_not_empty_string);
   gtk_widget_class_bind_template_callback (widget_class, is_not_empty_list);
   gtk_widget_class_bind_template_callback (widget_class, is_scrolled_down);
-  gtk_widget_class_bind_template_callback (widget_class, bind_widget_cb);
-  gtk_widget_class_bind_template_callback (widget_class, unbind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, featured_carousel_group_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, show_all_cb);
 }
@@ -511,12 +486,4 @@ bz_apps_page_set_subtitle (BzAppsPage *self,
     self->subtitle = g_strdup (subtitle);
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_PAGE_SUBTITLE]);
-}
-
-static void
-tile_clicked (BzEntryGroup *group,
-              GtkButton    *button)
-{
-  gtk_widget_activate_action (GTK_WIDGET (button), "window.show-group", "s",
-                              bz_entry_group_get_id (group));
 }

--- a/src/bz-curated-app-tile.blp
+++ b/src/bz-curated-app-tile.blp
@@ -4,6 +4,5 @@ using Adw 1;
 template $BzCuratedAppTile: Adw.Bin {
   child: $BzAppTile {
     group: bind template.group;
-    clicked => $clicked_cb(template);
   };
 }

--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -2,6 +2,7 @@ using Gtk 4.0;
 
 template $BzRichAppTile: $BzListTile {
   overflow: hidden;
+  activated => $tile_clicked_cb();
 
   accessibility {
     described-by: description;

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -216,6 +216,17 @@ bz_rich_app_tile_set_property (GObject      *object,
     }
 }
 
+static void
+tile_clicked_cb (GtkButton     *button,
+                 BzRichAppTile *self)
+{
+  if (self->group == NULL)
+    return;
+
+  gtk_widget_activate_action (GTK_WIDGET (self), "window.show-group", "s",
+                              bz_entry_group_get_id (self->group));
+}
+
 static gboolean
 invert_boolean (gpointer object,
                 gboolean value)
@@ -342,6 +353,7 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
   g_type_ensure (BZ_TYPE_THEMED_ENTRY_GROUP_RECT);
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-rich-app-tile.ui");
+  gtk_widget_class_bind_template_callback (widget_class, tile_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, is_zero);

--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -285,7 +285,6 @@ template $BzSearchPage: Adw.Bin {
                         $BzRichAppTile {
                           group: bind template.item as <$BzSearchResult>.group as <$BzEntryGroup>;
                           focusable: false;
-                          activated => $tile_activated_cb(template);
                         }
 
                         Box {

--- a/src/bz-search-page.c
+++ b/src/bz-search-page.c
@@ -310,17 +310,6 @@ unbind_category_tile_cb (BzSearchPage      *self,
 }
 
 static void
-tile_activated_cb (GtkListItem   *list_item,
-                   BzRichAppTile *tile)
-{
-  BzSearchResult *result = gtk_list_item_get_item (list_item);
-  BzEntryGroup   *group  = bz_search_result_get_group (result);
-
-  gtk_widget_activate_action (GTK_WIDGET (tile), "window.show-group", "s",
-                              bz_entry_group_get_id (group));
-}
-
-static void
 reset_search_cb (BzSearchPage *self,
                  GtkButton    *button)
 {
@@ -443,7 +432,6 @@ bz_search_page_class_init (BzSearchPageClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, reset_search_cb);
   gtk_widget_class_bind_template_callback (widget_class, pill_list_cb);
   gtk_widget_class_bind_template_callback (widget_class, no_results_found_subtitle);
-  gtk_widget_class_bind_template_callback (widget_class, tile_activated_cb);
   gtk_widget_class_bind_template_callback (widget_class, copy_id_cb);
   gtk_widget_class_bind_template_callback (widget_class, debug_id_inspect_cb);
 }


### PR DESCRIPTION
This reduces boilerplate, and makes the tiles more easily reusable.