### PR TITLE
reduce UI hitches when typing in search

### DIFF
--- a/src/bz-lazy-wdgt.c
+++ b/src/bz-lazy-wdgt.c
@@ -1,0 +1,350 @@
+/* bz-lazy-wdgt.c
+ *
+ * Copyright 2026 Eva M
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * BzLazyWdgt:
+ *
+ * Initializing a BgeWdgtRenderer can be expensive, so this allows you to have a
+ * placeholder widget until the state changes from a non-NULL value to another
+ * non-NULL value, at which point a proper renderer will be swapped in.
+ */
+
+#include "bz-lazy-wdgt.h"
+
+struct _BzLazyWdgt
+{
+  AdwBin parent_instance;
+
+  BgeWdgtSpec *wdgt_spec;
+  char        *wdgt_resource;
+  char        *wdgt_state;
+  GObject     *wdgt_reference;
+  gboolean     activated;
+};
+
+G_DEFINE_FINAL_TYPE (BzLazyWdgt, bz_lazy_wdgt, ADW_TYPE_BIN);
+
+enum
+{
+  PROP_0,
+
+  PROP_WDGT_SPEC,
+  PROP_WDGT_RESOURCE,
+  PROP_WDGT_STATE,
+  PROP_WDGT_REFERENCE,
+  PROP_WDGT_ACTIVATED,
+
+  LAST_PROP
+};
+static GParamSpec *props[LAST_PROP] = { 0 };
+
+static void
+maybe_activate (BzLazyWdgt *self);
+
+static void
+bz_lazy_wdgt_dispose (GObject *object)
+{
+  BzLazyWdgt *self = BZ_LAZY_WDGT (object);
+
+  g_clear_pointer (&self->wdgt_spec, g_object_unref);
+  g_clear_pointer (&self->wdgt_resource, g_free);
+  g_clear_pointer (&self->wdgt_state, g_free);
+  g_clear_pointer (&self->wdgt_reference, g_object_unref);
+
+  G_OBJECT_CLASS (bz_lazy_wdgt_parent_class)->dispose (object);
+}
+
+static void
+bz_lazy_wdgt_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  BzLazyWdgt *self = BZ_LAZY_WDGT (object);
+
+  switch (prop_id)
+    {
+    case PROP_WDGT_SPEC:
+      g_value_set_object (value, bz_lazy_wdgt_get_wdgt_spec (self));
+      break;
+    case PROP_WDGT_RESOURCE:
+      g_value_set_string (value, bz_lazy_wdgt_get_wdgt_resource (self));
+      break;
+    case PROP_WDGT_STATE:
+      g_value_set_string (value, bz_lazy_wdgt_get_wdgt_state (self));
+      break;
+    case PROP_WDGT_REFERENCE:
+      g_value_set_object (value, bz_lazy_wdgt_get_wdgt_reference (self));
+      break;
+    case PROP_WDGT_ACTIVATED:
+      g_value_set_boolean (value, bz_lazy_wdgt_get_activated (self));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+bz_lazy_wdgt_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  BzLazyWdgt *self = BZ_LAZY_WDGT (object);
+
+  switch (prop_id)
+    {
+    case PROP_WDGT_SPEC:
+      bz_lazy_wdgt_set_wdgt_spec (self, g_value_get_object (value));
+      break;
+    case PROP_WDGT_RESOURCE:
+      bz_lazy_wdgt_set_wdgt_resource (self, g_value_get_string (value));
+      break;
+    case PROP_WDGT_STATE:
+      bz_lazy_wdgt_set_wdgt_state (self, g_value_get_string (value));
+      break;
+    case PROP_WDGT_REFERENCE:
+      bz_lazy_wdgt_set_wdgt_reference (self, g_value_get_object (value));
+      break;
+    case PROP_WDGT_ACTIVATED:
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+bz_lazy_wdgt_class_init (BzLazyWdgtClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = bz_lazy_wdgt_set_property;
+  object_class->get_property = bz_lazy_wdgt_get_property;
+  object_class->dispose      = bz_lazy_wdgt_dispose;
+
+  props[PROP_WDGT_SPEC] =
+      g_param_spec_object (
+          "wdgt-spec",
+          NULL, NULL,
+          BGE_TYPE_WDGT_SPEC,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_WDGT_RESOURCE] =
+      g_param_spec_string (
+          "wdgt-resource",
+          NULL, NULL, NULL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_WDGT_STATE] =
+      g_param_spec_string (
+          "wdgt-state",
+          NULL, NULL, NULL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_WDGT_REFERENCE] =
+      g_param_spec_object (
+          "wdgt-reference",
+          NULL, NULL,
+          G_TYPE_OBJECT,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_WDGT_ACTIVATED] =
+      g_param_spec_boolean (
+          "activated",
+          NULL, NULL, FALSE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  g_object_class_install_properties (object_class, LAST_PROP, props);
+}
+
+static void
+bz_lazy_wdgt_init (BzLazyWdgt *self)
+{
+}
+
+BzLazyWdgt *
+bz_lazy_wdgt_new (void)
+{
+  return g_object_new (BZ_TYPE_LAZY_WDGT, NULL);
+}
+
+BgeWdgtSpec *
+bz_lazy_wdgt_get_wdgt_spec (BzLazyWdgt *self)
+{
+  g_return_val_if_fail (BZ_IS_LAZY_WDGT (self), NULL);
+  return self->wdgt_spec;
+}
+
+const char *
+bz_lazy_wdgt_get_wdgt_resource (BzLazyWdgt *self)
+{
+  g_return_val_if_fail (BZ_IS_LAZY_WDGT (self), NULL);
+  return self->wdgt_resource;
+}
+
+const char *
+bz_lazy_wdgt_get_wdgt_state (BzLazyWdgt *self)
+{
+  g_return_val_if_fail (BZ_IS_LAZY_WDGT (self), NULL);
+  return self->wdgt_state;
+}
+
+GObject *
+bz_lazy_wdgt_get_wdgt_reference (BzLazyWdgt *self)
+{
+  g_return_val_if_fail (BZ_IS_LAZY_WDGT (self), NULL);
+  return self->wdgt_reference;
+}
+
+gboolean
+bz_lazy_wdgt_get_activated (BzLazyWdgt *self)
+{
+  g_return_val_if_fail (BZ_IS_LAZY_WDGT (self), FALSE);
+  return self->activated;
+}
+
+void
+bz_lazy_wdgt_set_wdgt_spec (BzLazyWdgt  *self,
+                            BgeWdgtSpec *wdgt_spec)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+  g_return_if_fail (wdgt_spec == NULL || BGE_IS_WDGT_SPEC (wdgt_spec));
+
+  if (wdgt_spec == self->wdgt_spec)
+    return;
+
+  g_clear_pointer (&self->wdgt_spec, g_object_unref);
+  if (wdgt_spec != NULL)
+    self->wdgt_spec = g_object_ref (wdgt_spec);
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_SPEC]);
+}
+
+void
+bz_lazy_wdgt_set_wdgt_resource (BzLazyWdgt *self,
+                                const char *wdgt_resource)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+
+  if (wdgt_resource == self->wdgt_resource || (wdgt_resource != NULL && self->wdgt_resource != NULL && g_strcmp0 (wdgt_resource, self->wdgt_resource) == 0))
+    return;
+
+  g_clear_pointer (&self->wdgt_resource, g_free);
+  if (wdgt_resource != NULL)
+    self->wdgt_resource = g_strdup (wdgt_resource);
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_RESOURCE]);
+}
+
+void
+bz_lazy_wdgt_set_wdgt_state (BzLazyWdgt *self,
+                             const char *wdgt_state)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+
+  if (wdgt_state == self->wdgt_state || (wdgt_state != NULL && self->wdgt_state != NULL && g_strcmp0 (wdgt_state, self->wdgt_state) == 0))
+    return;
+
+  g_clear_pointer (&self->wdgt_state, g_free);
+  if (wdgt_state != NULL)
+    {
+      self->wdgt_state = g_strdup (wdgt_state);
+      maybe_activate (self);
+    }
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_STATE]);
+}
+
+void
+bz_lazy_wdgt_set_wdgt_reference (BzLazyWdgt *self,
+                                 GObject    *wdgt_reference)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+  g_return_if_fail (wdgt_reference == NULL || G_IS_OBJECT (wdgt_reference));
+
+  if (wdgt_reference == self->wdgt_reference)
+    return;
+
+  g_clear_pointer (&self->wdgt_reference, g_object_unref);
+  if (wdgt_reference != NULL)
+    self->wdgt_reference = g_object_ref (wdgt_reference);
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_REFERENCE]);
+}
+
+void
+bz_lazy_wdgt_set_wdgt_resource_take (BzLazyWdgt *self,
+                                     char       *wdgt_resource)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+
+  if (wdgt_resource != NULL && self->wdgt_resource != NULL && g_strcmp0 (wdgt_resource, self->wdgt_resource) == 0)
+    {
+      g_free (wdgt_resource);
+      return;
+    }
+
+  g_clear_pointer (&self->wdgt_resource, g_free);
+  if (wdgt_resource != NULL)
+    self->wdgt_resource = wdgt_resource;
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_RESOURCE]);
+}
+
+void
+bz_lazy_wdgt_set_wdgt_state_take (BzLazyWdgt *self,
+                                  char       *wdgt_state)
+{
+  g_return_if_fail (BZ_IS_LAZY_WDGT (self));
+
+  if (wdgt_state != NULL && self->wdgt_state != NULL && g_strcmp0 (wdgt_state, self->wdgt_state) == 0)
+    {
+      g_free (wdgt_state);
+      return;
+    }
+
+  g_clear_pointer (&self->wdgt_state, g_free);
+  if (wdgt_state != NULL)
+    {
+      self->wdgt_state = wdgt_state;
+      maybe_activate (self);
+    }
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_WDGT_STATE]);
+}
+
+static void
+maybe_activate (BzLazyWdgt *self)
+{
+  BgeWdgtRenderer *renderer = NULL;
+
+  if (self->activated)
+    return;
+
+  renderer = bge_wdgt_renderer_new ();
+  g_object_bind_property (self, "wdgt-spec", renderer, "spec", G_BINDING_SYNC_CREATE);
+  g_object_bind_property (self, "wdgt-resource", renderer, "resource", G_BINDING_SYNC_CREATE);
+  g_object_bind_property (self, "wdgt-state", renderer, "state", G_BINDING_SYNC_CREATE);
+  g_object_bind_property (self, "wdgt-reference", renderer, "reference", G_BINDING_SYNC_CREATE);
+
+  adw_bin_set_child (ADW_BIN (self), GTK_WIDGET (renderer));
+  self->activated = TRUE;
+}
+
+/* End of bz-lazy-wdgt.c */

--- a/src/bz-lazy-wdgt.h
+++ b/src/bz-lazy-wdgt.h
@@ -1,0 +1,79 @@
+/* bz-lazy-wdgt.h
+ *
+ * Copyright 2026 Eva M
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <adwaita.h>
+#include <bge.h>
+
+G_BEGIN_DECLS
+
+#define BZ_TYPE_LAZY_WDGT (bz_lazy_wdgt_get_type ())
+G_DECLARE_FINAL_TYPE (BzLazyWdgt, bz_lazy_wdgt, BZ, LAZY_WDGT, AdwBin)
+
+BzLazyWdgt *
+bz_lazy_wdgt_new (void);
+
+BgeWdgtSpec *
+bz_lazy_wdgt_get_wdgt_spec (BzLazyWdgt *self);
+
+const char *
+bz_lazy_wdgt_get_wdgt_resource (BzLazyWdgt *self);
+
+const char *
+bz_lazy_wdgt_get_wdgt_state (BzLazyWdgt *self);
+
+GObject *
+bz_lazy_wdgt_get_wdgt_reference (BzLazyWdgt *self);
+
+gboolean
+bz_lazy_wdgt_get_activated (BzLazyWdgt *self);
+
+void
+bz_lazy_wdgt_set_wdgt_spec (BzLazyWdgt  *self,
+                            BgeWdgtSpec *wdgt_spec);
+
+void
+bz_lazy_wdgt_set_wdgt_resource (BzLazyWdgt *self,
+                                const char *wdgt_resource);
+
+void
+bz_lazy_wdgt_set_wdgt_state (BzLazyWdgt *self,
+                             const char *wdgt_state);
+
+void
+bz_lazy_wdgt_set_wdgt_reference (BzLazyWdgt *self,
+                                 GObject    *wdgt_reference);
+
+void
+bz_lazy_wdgt_set_wdgt_resource_take (BzLazyWdgt *self,
+                                     char       *wdgt_resource);
+
+#define bz_lazy_wdgt_set_wdgt_resource_take_printf(self, ...) bz_lazy_wdgt_set_wdgt_resource_take (self, g_strdup_printf (__VA_ARGS__))
+
+void
+bz_lazy_wdgt_set_wdgt_state_take (BzLazyWdgt *self,
+                                  char       *wdgt_state);
+
+#define bz_lazy_wdgt_set_wdgt_state_take_printf(self, ...) bz_lazy_wdgt_set_wdgt_state_take (self, g_strdup_printf (__VA_ARGS__))
+
+G_END_DECLS
+
+/* End of bz-lazy-wdgt.h */

--- a/src/bz-search-page.c
+++ b/src/bz-search-page.c
@@ -634,7 +634,7 @@ search_changed (GtkEditable  *editable,
 {
   g_clear_handle_id (&self->search_update_timeout, g_source_remove);
   self->search_update_timeout = g_timeout_add_once (
-      150, (GSourceOnceFunc) update_filter, self);
+      300, (GSourceOnceFunc) update_filter, self);
   gtk_widget_set_visible (GTK_WIDGET (self->search_busy), TRUE);
 }
 

--- a/src/bz-transact-icon.c
+++ b/src/bz-transact-icon.c
@@ -21,6 +21,7 @@
 #include <bge.h>
 
 #include "bz-application.h"
+#include "bz-lazy-wdgt.h"
 #include "bz-transact-icon.h"
 #include "progress-bar-designs/common.h"
 
@@ -37,7 +38,7 @@ struct _BzTransactIcon
 
   char *pride_class;
 
-  BgeWdgtRenderer *wdgt;
+  BzLazyWdgt *wdgt;
 };
 
 G_DEFINE_FINAL_TYPE (BzTransactIcon, bz_transact_icon, ADW_TYPE_BIN);
@@ -98,6 +99,11 @@ static void
 pride_flag_changed (BzTransactIcon *self,
                     const char     *key,
                     GSettings      *settings);
+
+static gboolean
+next_frame_tick_cb (GtkWidget     *widget,
+                    GdkFrameClock *frame_clock,
+                    char          *apply_state);
 
 static void
 bz_transact_icon_dispose (GObject *object)
@@ -192,14 +198,19 @@ bz_transact_icon_class_init (BzTransactIconClass *klass)
 static void
 bz_transact_icon_init (BzTransactIcon *self)
 {
-  self->wdgt = bge_wdgt_renderer_new ();
-  g_object_set (
-      self->wdgt,
-      "resource", "/io/github/kolunmi/Bazaar/bz-transact-icon.wdgt",
-      "state", "inactive",
-      NULL);
-  g_object_bind_property (self, "info", self->wdgt, "reference", G_BINDING_DEFAULT);
+  GtkWidget *placeholder_icon = NULL;
+
+  self->wdgt = bz_lazy_wdgt_new ();
+  bz_lazy_wdgt_set_wdgt_resource (self->wdgt, "/io/github/kolunmi/Bazaar/bz-transact-icon.wdgt");
+  g_object_bind_property (self, "info", self->wdgt, "wdgt-reference", G_BINDING_DEFAULT);
   adw_bin_set_child (ADW_BIN (self), GTK_WIDGET (self->wdgt));
+
+  placeholder_icon = gtk_image_new ();
+  gtk_widget_add_css_class (placeholder_icon, "icon-dropshadow");
+  g_object_bind_property (self, "height-request", placeholder_icon, "pixel-size", G_BINDING_SYNC_CREATE);
+
+  adw_bin_set_child (ADW_BIN (self->wdgt), placeholder_icon);
+  update_icon (self);
 }
 
 BzTransactIcon *
@@ -391,16 +402,37 @@ check_tracker (BzTransactIcon *self)
   else
     state = "inactive";
 
-  bge_wdgt_renderer_set_state (self->wdgt, state);
+  if (!bz_lazy_wdgt_get_activated (self->wdgt))
+    {
+      /* Ensure smooth animation from idle; hacky but if we schedule the state
+         change on the next animation tick, then it will appear to smoothly
+         animate from the placeholder */
+      bz_lazy_wdgt_set_wdgt_state (self->wdgt, "inactive");
+      gtk_widget_add_tick_callback (
+          GTK_WIDGET (self),
+          (GtkTickCallback) next_frame_tick_cb,
+          g_strdup (state), g_free);
+    }
+  else
+    bz_lazy_wdgt_set_wdgt_state (self->wdgt, state);
+
+  update_icon (self);
+  ensure_draw_css (self);
 }
 
 static void
 ensure_draw_css (BzTransactIcon *self)
 {
+  GtkWidget *renderer          = NULL;
   g_autoptr (GtkWidget) widget = NULL;
   g_autofree char *id          = NULL;
   g_autofree char *class       = NULL;
-  widget = bge_wdgt_renderer_lookup_object (self->wdgt, "flag");
+
+  renderer = adw_bin_get_child (ADW_BIN (self->wdgt));
+  if (!BGE_IS_WDGT_RENDERER (renderer))
+    return;
+
+  widget = bge_wdgt_renderer_lookup_object (BGE_WDGT_RENDERER (renderer), "flag");
 
   if (self->settings == NULL)
     {
@@ -427,18 +459,23 @@ ensure_draw_css (BzTransactIcon *self)
 static void
 update_icon (BzTransactIcon *self)
 {
-  g_autoptr (GtkImage) icon = NULL;
-  GdkPaintable *paintable   = NULL;
+  GtkWidget *renderer        = NULL;
+  g_autoptr (GtkWidget) icon = NULL;
+  GdkPaintable *paintable    = NULL;
 
-  icon = bge_wdgt_renderer_lookup_object (self->wdgt, "icon");
+  renderer = adw_bin_get_child (ADW_BIN (self->wdgt));
+  if (BGE_IS_WDGT_RENDERER (renderer))
+    icon = bge_wdgt_renderer_lookup_object (BGE_WDGT_RENDERER (renderer), "icon");
+  else
+    icon = g_object_ref (renderer);
 
   if (self->info != NULL)
     paintable = bz_transact_icon_info_get_paintable (self->info);
 
   if (paintable != NULL)
-    gtk_image_set_from_paintable (icon, paintable);
+    gtk_image_set_from_paintable (GTK_IMAGE (icon), paintable);
   else
-    gtk_image_set_from_icon_name (icon, "application-x-executable");
+    gtk_image_set_from_icon_name (GTK_IMAGE (icon), "application-x-executable");
 }
 
 static void
@@ -489,6 +526,17 @@ pride_flag_changed (BzTransactIcon *self,
                     GSettings      *settings)
 {
   ensure_draw_css (self);
+}
+
+static gboolean
+next_frame_tick_cb (GtkWidget     *widget,
+                    GdkFrameClock *frame_clock,
+                    char          *apply_state)
+{
+  BzTransactIcon *self = BZ_TRANSACT_ICON (widget);
+
+  bz_lazy_wdgt_set_wdgt_state (self->wdgt, apply_state);
+  return G_SOURCE_REMOVE;
 }
 
 /* End of bz-transact-icon.c */

--- a/src/meson.build
+++ b/src/meson.build
@@ -115,6 +115,7 @@ bz_sources = files(
   'bz-install-controls.c',
   'bz-installed-tile.c',
   'bz-io.c',
+  'bz-lazy-wdgt.c',
   'bz-library-page.c',
   'bz-license-dialog.c',
   'bz-list-tile.c',


### PR DESCRIPTION
this commit introduces a new widget `BzLazyWdgt` which lazily creates `BgeWdgtRenderer`s based on when they are needed in search results, reducing the amount of cpu time needed to batch create a bunch of these fairly heavy widgets in the grid view.

Also increase search debounce time from 150ms -> 300ms which is better for average typing speeds