### PR TITLE
Load the example curation file in dev builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -117,14 +117,14 @@ else
       config_h.set_quoted('SANDBOXED_LIBFLATPAK', '1')
     endif
 
-if get_option('development')
-  config_h.set10('DEVELOPMENT_BUILD', get_option('development'))
-  config_h.set_quoted('DEVELOPMENT_EXAMPLE_YAML', get_option('prefix') / get_option('datadir') / 'bazaar' / 'example.yaml')
-  install_data(
-    'docs/example.yaml',
-    install_dir: get_option('datadir') / 'bazaar',
-  )
-endif
+    if get_option('development')
+      config_h.set10('DEVELOPMENT_BUILD', get_option('development'))
+      config_h.set_quoted('DEVELOPMENT_EXAMPLE_YAML', get_option('prefix') / get_option('datadir') / 'bazaar' / 'example.yaml')
+      install_data(
+        'docs/example.yaml',
+        install_dir: get_option('datadir') / 'bazaar',
+      )
+    endif
 
     configure_file(output: 'config.h', configuration: config_h)
     add_project_arguments(['-I' + meson.project_build_root()], language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -117,9 +117,14 @@ else
       config_h.set_quoted('SANDBOXED_LIBFLATPAK', '1')
     endif
 
-    if get_option('development')
-      config_h.set10('DEVELOPMENT_BUILD', get_option('development'))
-    endif
+if get_option('development')
+  config_h.set10('DEVELOPMENT_BUILD', get_option('development'))
+  config_h.set_quoted('DEVELOPMENT_EXAMPLE_YAML', get_option('prefix') / get_option('datadir') / 'bazaar' / 'example.yaml')
+  install_data(
+    'docs/example.yaml',
+    install_dir: get_option('datadir') / 'bazaar',
+  )
+endif
 
     configure_file(output: 'config.h', configuration: config_h)
     add_project_arguments(['-I' + meson.project_build_root()], language: 'c')

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -3211,6 +3211,23 @@ init_service_struct (BzApplication *self,
           gtk_string_list_append (curated_configs, gtk_string_object_get_string (string));
         }
     }
+
+#ifdef DEVELOPMENT_BUILD
+  if (g_list_model_get_n_items (G_LIST_MODEL (curated_configs)) == 0)
+    {
+      g_autofree char *dest_path  = NULL;
+      g_autoptr (GFile) src       = NULL;
+      g_autoptr (GFile) dest      = NULL;
+
+      dest_path = g_build_filename (g_get_user_data_dir (), "example.yaml", NULL);
+      src       = g_file_new_for_path (DEVELOPMENT_EXAMPLE_YAML);
+      dest      = g_file_new_for_path (dest_path);
+      g_file_copy (src, dest, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+
+      gtk_string_list_append (curated_configs, dest_path);
+    }
+#endif
+
   self->curated_configs          = g_object_ref (curated_configs);
   self->curated_configs_to_files = gtk_map_list_model_new (
       NULL, (GtkMapListModelMapFunc) map_strings_to_files, NULL, NULL);

--- a/src/bz-inspector.c
+++ b/src/bz-inspector.c
@@ -22,6 +22,8 @@
 
 #include <json-glib/json-glib.h>
 
+#include "config.h"
+
 #include "bz-entry-inspector.h"
 #include "bz-env.h"
 #include "bz-inspector.h"
@@ -236,13 +238,25 @@ open_file_externally_cb (GtkListItem *list_item,
 {
   GtkStringObject *string = NULL;
   const char      *path   = NULL;
-  g_autofree char *uri    = NULL;
 
   string = gtk_list_item_get_item (list_item);
   path   = gtk_string_object_get_string (string);
 
-  uri = g_strdup_printf ("file://%s", path);
-  g_app_info_launch_default_for_uri (uri, NULL, NULL);
+#if defined(DEVELOPMENT_BUILD) && defined(SANDBOXED_LIBFLATPAK)
+  {
+    const char *argv[] = { "flatpak-spawn", "--host", "xdg-open", NULL, NULL };
+    argv[3] = path;
+
+    g_spawn_async (NULL, (char **) argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
+  }
+#else
+  {
+    g_autofree char *uri = NULL;
+
+    uri = g_strdup_printf ("file://%s", path);
+    g_app_info_launch_default_for_uri (uri, NULL, NULL);
+  }
+#endif
 }
 
 static void


### PR DESCRIPTION
Having a curated file always loaded when developing should make regressions in the curated section more obvious.