### PR TITLE
Stop auto syncing on metered connection at startup (or after 24h)

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -2100,8 +2100,6 @@ init_fiber_finally (DexFuture *future,
   value = dex_future_get_value (future, &local_error);
   if (value != NULL)
     {
-      g_autoptr (DexFuture) sync_future = NULL;
-
       self->flatpak_notifs = bz_backend_create_notification_channel (
           BZ_BACKEND (self->flatpak));
       self->notif_watch = dex_future_then_loop (
@@ -2110,13 +2108,33 @@ init_fiber_finally (DexFuture *future,
           bz_track_weak (self),
           bz_weak_release);
 
-      sync_future = make_sync_future (self);
-      sync_future = dex_future_finally (
-          sync_future,
-          (DexFutureCallback) init_sync_finally,
-          bz_track_weak (self),
-          bz_weak_release);
-      self->sync = g_steal_pointer (&sync_future);
+      if (!bz_state_info_get_metered_connection (self->state))
+        {
+          g_autoptr (DexFuture) sync_future = NULL;
+
+          sync_future = make_sync_future (self);
+          sync_future = dex_future_finally (
+              sync_future,
+              (DexFutureCallback) init_sync_finally,
+              bz_track_weak (self),
+              bz_weak_release);
+          self->sync = g_steal_pointer (&sync_future);
+        }
+      else
+        {
+          bz_state_info_set_allow_manual_sync (self->state, TRUE);
+          bz_state_info_set_busy (self->state, FALSE);
+          bz_state_info_set_syncing (self->state, FALSE);
+          dex_promise_resolve_boolean (self->ready_to_open_files, TRUE);
+
+          // Only check for updates if connection is limited.
+          dex_future_disown (dex_scheduler_spawn (
+              dex_scheduler_get_default (),
+              bz_get_dex_stack_size (),
+              (DexFiberFunc) check_for_updates_fiber,
+              bz_track_weak (self),
+              bz_weak_release));
+        }
 
       self->periodic_timeout_source = g_timeout_add_seconds (
           /* Check every day */
@@ -2641,6 +2659,8 @@ periodic_timeout_cb (BzApplication *self)
     /* Do not do periodic sync on metered connections. The user will have to
        manually refresh instead. */
     self->sync = make_sync_future (self);
+  else
+    bz_state_info_set_recently_synced (self->state, FALSE);
 
 done:
   return G_SOURCE_CONTINUE;
@@ -3977,6 +3997,7 @@ make_sync_future (BzApplication *self)
   bz_state_info_set_allow_manual_sync (self->state, FALSE);
 
   bz_state_info_set_syncing (self->state, TRUE);
+  bz_state_info_set_recently_synced (self->state, TRUE);
   finish_with_background_task_label (self);
 
   refresh_worker = g_subprocess_new (

--- a/src/bz-state-info.txt
+++ b/src/bz-state-info.txt
@@ -47,6 +47,7 @@ property=hide_eol gboolean G_TYPE_BOOLEAN boolean
 property=internal_config BzInternalConfig BZ_TYPE_INTERNAL_CONFIG object
 property=main_config BzMainConfig BZ_TYPE_MAIN_CONFIG object
 property=metered_connection gboolean G_TYPE_BOOLEAN boolean
+property=recently_synced gboolean G_TYPE_BOOLEAN boolean
 property=online gboolean G_TYPE_BOOLEAN boolean
 property=repositories GListModel G_TYPE_LIST_MODEL object
 property=search_engine BzSearchEngine BZ_TYPE_SEARCH_ENGINE object

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -235,6 +235,17 @@ template $BzWindow: Adw.ApplicationWindow {
                   button-label: _("Refresh Manually");
                   button-clicked => $sync_cb(template);
                 }
+
+                Adw.Banner {
+                  sensitive: bind $invert_boolean(template.state as <$BzStateInfo>.syncing as <bool>) as <bool>;
+                  revealed: bind $logical_and(
+                      $invert_boolean(template.state as <$BzStateInfo>.recently-synced as <bool>) as <bool>,
+                      $logical_and(template.state as <$BzStateInfo>.metered_connection as <bool>, template.state as <$BzStateInfo>.have_connection as <bool>) as <bool>
+                  ) as <bool>;
+                  title: _("Network connection is metered — automatic refreshes disabled");
+                  button-label: _("Refresh Manually");
+                  button-clicked => $sync_cb(template);
+                }
               }
 
               [bottom]


### PR DESCRIPTION
The update fetching still happens automatically, the banner also re-appears after daily background refresh fails.

<img width="1020" height="932" alt="Screenshot From 2026-06-26 18-05-59" src="https://github.com/user-attachments/assets/a866a7f4-8184-4be7-a704-eb78ded52c7c" />
