### PR TITLE
Hide runtime row when no runtime is found

### DIFF
--- a/src/bz-app-size-dialog.blp
+++ b/src/bz-app-size-dialog.blp
@@ -82,8 +82,8 @@ template $BzAppSizeDialog: Adw.Bin {
             subtitle: _("Size on Disk");
           }
 
-          Adw.ActionRow {
-            visible: bind $invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object) as <bool>) as <bool>;
+          Adw.ActionRow runtime_row {
+            visible: bind try {$invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object) as <bool>) as <bool>, false};
             [prefix]
             Label {
               label: bind $format_size($choose(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.installed, template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.installed-size as <uint64>, template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.size as <uint64>) as <int>, false) as <string>;


### PR DESCRIPTION
This happened for add-ons