### PR TITLE
Don't skip initial refresh on metered connection when there is no cache

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -127,6 +127,7 @@ struct _BzApplication
   GtkStringList              *txt_blocklists;
   gboolean                    flathub_remote_initialized;
   gboolean                    running;
+  gboolean                    had_cache_on_init;
   guint                       periodic_timeout_source;
   int                         n_entries_incoming;
   int                         n_remotes_syncing;
@@ -1238,6 +1239,8 @@ init_fiber (GWeakRef *wr)
           bz_weak_release),
       NULL);
 
+  self->had_cache_on_init = g_list_model_get_n_items (G_LIST_MODEL (self->groups)) > 0;
+
   flathub_cache_file = fiber_dup_cache_file ("flathub-cache", &flathub_cache, &local_error);
   if (flathub_cache_file != NULL)
     {
@@ -2178,7 +2181,7 @@ init_fiber_finally (DexFuture *future,
           bz_track_weak (self),
           bz_weak_release);
 
-      if (!bz_state_info_get_metered_connection (self->state))
+      if (!bz_state_info_get_metered_connection (self->state) || !self->had_cache_on_init)
         {
           g_autoptr (DexFuture) sync_future = NULL;
 

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -236,6 +236,17 @@ template $BzWindow: Adw.ApplicationWindow {
                     button-label: _("Refresh Manually");
                     button-clicked => $sync_cb(template);
                   }
+
+                  Adw.Banner {
+                    sensitive: bind $invert_boolean(template.state as <$BzStateInfo>.syncing as <bool>) as <bool>;
+                    revealed: bind $logical_and(
+                        $invert_boolean(template.state as <$BzStateInfo>.recently-synced as <bool>) as <bool>,
+                        $logical_and(template.state as <$BzStateInfo>.metered_connection as <bool>, template.state as <$BzStateInfo>.have_connection as <bool>) as <bool>
+                    ) as <bool>;
+                    title: _("Network connection is metered — automatic refreshes disabled");
+                    button-label: _("Refresh Manually");
+                    button-clicked => $sync_cb(template);
+                  }
                 }
 
                 [bottom]


### PR DESCRIPTION
You seem to also have accidentally removed the metered connection banner in this commit: https://github.com/bazaar-org/bazaar/tree/93cf1bdb30b49ec68b71585f2b088bc4165fff9c