### PR TITLE
Add "similar apps" section to full view

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -101,6 +101,7 @@ typedef struct
   char             *developer;
   char             *developer_id;
   GListModel       *developer_apps;
+  GListModel       *similar_apps;
   GListModel       *screenshot_paintables;
   GListModel       *screenshot_captions;
   GdkPaintable     *thumbnail_paintable;
@@ -168,6 +169,7 @@ enum
   PROP_DEVELOPER,
   PROP_DEVELOPER_ID,
   PROP_DEVELOPER_APPS,
+  PROP_SIMILAR_APPS,
   PROP_SCREENSHOT_PAINTABLES,
   PROP_SCREENSHOT_CAPTIONS,
   PROP_THUMBNAIL_PAINTABLE,
@@ -351,6 +353,10 @@ bz_entry_get_property (GObject    *object,
     case PROP_DEVELOPER_APPS:
       query_flathub (self, PROP_DEVELOPER_APPS);
       g_value_set_object (value, priv->developer_apps);
+      break;
+    case PROP_SIMILAR_APPS:
+      query_flathub (self, PROP_SIMILAR_APPS);
+      g_value_set_object (value, priv->similar_apps);
       break;
     case PROP_SCREENSHOT_PAINTABLES:
       g_value_set_object (value, priv->screenshot_paintables);
@@ -558,6 +564,10 @@ bz_entry_set_property (GObject      *object,
     case PROP_DEVELOPER_APPS:
       g_clear_object (&priv->developer_apps);
       priv->developer_apps = g_value_dup_object (value);
+      break;
+    case PROP_SIMILAR_APPS:
+      g_clear_object (&priv->similar_apps);
+      priv->similar_apps = g_value_dup_object (value);
       break;
     case PROP_SCREENSHOT_PAINTABLES:
       g_clear_object (&priv->screenshot_paintables);
@@ -853,6 +863,13 @@ bz_entry_class_init (BzEntryClass *klass)
   props[PROP_DEVELOPER_APPS] =
       g_param_spec_object (
           "developer-apps",
+          NULL, NULL,
+          G_TYPE_LIST_MODEL,
+          G_PARAM_READWRITE);
+
+  props[PROP_SIMILAR_APPS] =
+      g_param_spec_object (
+          "similar-apps",
           NULL, NULL,
           G_TYPE_LIST_MODEL,
           G_PARAM_READWRITE);
@@ -2399,6 +2416,7 @@ query_flathub (BzEntry *self,
   g_autoptr (QueryFlathubData) data = NULL;
   g_autoptr (DexFuture) future      = NULL;
   gboolean is_download_stat         = FALSE;
+  gboolean is_similar_apps          = FALSE;
 
   priv = bz_entry_get_instance_private (self);
 
@@ -2406,8 +2424,9 @@ query_flathub (BzEntry *self,
                       prop == PROP_DOWNLOAD_STATS_PER_COUNTRY ||
                       prop == PROP_RECENT_DOWNLOADS ||
                       prop == PROP_TOTAL_DOWNLOADS);
+  is_similar_apps = (prop == PROP_SIMILAR_APPS);
 
-  if (!is_download_stat && !priv->is_flathub)
+  if (!is_download_stat && !is_similar_apps && !priv->is_flathub)
     return;
   if (priv->id == NULL)
     return;
@@ -2471,12 +2490,19 @@ query_flathub_fiber (QueryFlathubData *data)
     case PROP_FAVORITES_COUNT:
       request = g_strdup_printf ("/favorites/%s/count", id);
       break;
+    case PROP_SIMILAR_APPS:
+      request = g_strdup_printf ("/similar/%s", id);
+      break;
     default:
       g_assert_not_reached ();
       return NULL;
     }
 
-  node = dex_await_boxed (bz_query_flathub_v2_json (request), &local_error);
+  if (prop == PROP_SIMILAR_APPS)
+    node = dex_await_boxed (bz_query_bazaar_json (request), &local_error);
+  else
+    node = dex_await_boxed (bz_query_flathub_v2_json (request), &local_error);
+
   if (node == NULL)
     {
       if (!g_error_matches (local_error, DEX_ERROR, DEX_ERROR_FIBER_CANCELLED))
@@ -2594,6 +2620,31 @@ query_flathub_fiber (QueryFlathubData *data)
           favorites_count = json_object_get_int_member (json_node_get_object (node), "favorites_count");
 
         return dex_future_new_for_int (favorites_count);
+      }
+      break;
+
+    case PROP_SIMILAR_APPS:
+      {
+        JsonArray *array                  = NULL;
+        g_autoptr (GtkStringList) app_ids = NULL;
+
+        if (!JSON_NODE_HOLDS_ARRAY (node))
+          return dex_future_new_for_error (
+              g_error_new (G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                           "Unexpected JSON response format"));
+
+        array   = json_node_get_array (node);
+        app_ids = gtk_string_list_new (NULL);
+
+        for (guint i = 0; i < json_array_get_length (array); i++)
+          {
+            const char *app_id = json_array_get_string_element (array, i);
+
+            if (app_id != NULL)
+              gtk_string_list_append (app_ids, app_id);
+          }
+
+        return dex_future_new_for_object (app_ids);
       }
       break;
 
@@ -2808,6 +2859,7 @@ clear_entry (BzEntry *self)
   g_clear_pointer (&priv->developer, g_free);
   g_clear_pointer (&priv->developer_id, g_free);
   g_clear_object (&priv->developer_apps);
+  g_clear_object (&priv->similar_apps);
   g_clear_object (&priv->screenshot_paintables);
   g_clear_object (&priv->screenshot_captions);
   g_clear_object (&priv->thumbnail_paintable);

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -668,6 +668,44 @@ template $BzFullView: Adw.Bin {
 
                         Box {
                           orientation: vertical;
+                          visible: bind $invert_boolean($is_zero(similar_apps_model.n-items) as <int>) as <bool>;
+
+                          Label {
+                            styles [
+                              "heading",
+                              "h4",
+                            ]
+
+                            label: _("Similar Apps");
+                            xalign: 0;
+                            wrap: true;
+                            wrap-mode: word_char;
+                            margin-top: 5;
+                            margin-bottom: 8;
+                            margin-start: 3;
+                          }
+
+                          $BzDynamicListView {
+                            hexpand: true;
+                            scroll: false;
+                            noscroll-kind: flow-box;
+                            child-type: "BzAppTile";
+                            child-prop: "group";
+                            max-children-per-line: 3;
+                            bind-widget => $bind_app_tile_cb(template);
+                            unbind-widget => $unbind_app_tile_cb(template);
+
+                            model: SliceListModel similar_apps_model {
+                              offset: 0;
+                              size: 6;
+                              model: bind $get_developer_apps_entries(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.similar-apps, template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>) as <Gio.ListModel>;
+                            };
+                          }
+
+                        }
+
+                        Box {
+                          orientation: vertical;
                           visible: bind $invert_boolean($is_zero(other_apps_model.n-items) as <int>) as <bool>;
 
                           Label {
@@ -691,7 +729,7 @@ template $BzFullView: Adw.Bin {
                             noscroll-kind: flow-box;
                             child-type: "BzAppTile";
                             child-prop: "group";
-                            max-children-per-line: bind $get_dev_apps_max_children_per_line(other_apps_model.model) as <int>;
+                            max-children-per-line: 3;
                             bind-widget => $bind_app_tile_cb(template);
                             unbind-widget => $unbind_app_tile_cb(template);
 

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -275,14 +275,6 @@ get_developer_apps_entries (gpointer object, GtkStringList *app_ids, BzEntry *en
   return bz_application_map_factory_generate (factory, G_LIST_MODEL (filtered));
 }
 
-static int
-get_dev_apps_max_children_per_line (gpointer object, GListModel *model)
-{
-  if (!model)
-    return 3;
-  return g_list_model_get_n_items (model) > 2 ? 3 : 2;
-}
-
 static void
 more_apps_button_clicked_cb (BzFullView *self,
                              GtkButton  *button)
@@ -765,7 +757,6 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_other_apps_label);
   gtk_widget_class_bind_template_callback (widget_class, format_more_other_apps_label);
   gtk_widget_class_bind_template_callback (widget_class, get_developer_apps_entries);
-  gtk_widget_class_bind_template_callback (widget_class, get_dev_apps_max_children_per_line);
   gtk_widget_class_bind_template_callback (widget_class, more_apps_button_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, open_url_cb);
   gtk_widget_class_bind_template_callback (widget_class, license_cb);

--- a/src/bz-global-net.c
+++ b/src/bz-global-net.c
@@ -58,9 +58,9 @@ send (SoupMessage   *message,
       gboolean       close_output);
 
 static DexFuture *
-query_flathub_v2_json_with_method (const char *request,
-                                   const char *method,
-                                   const char *token);
+query_uri_json_with_method (const char *uri,
+                            const char *method,
+                            const char *token);
 
 GProxyResolver *
 bz_get_default_proxy_resolver (void)
@@ -134,8 +134,12 @@ bz_https_query_json (const char *uri)
 DexFuture *
 bz_query_flathub_v2_json (const char *request)
 {
+  g_autofree char *uri = NULL;
+
   dex_return_error_if_fail (request != NULL);
-  return query_flathub_v2_json_with_method (request, SOUP_METHOD_GET, NULL);
+
+  uri = g_strdup_printf ("https://flathub.org/api/v2%s", request);
+  return query_uri_json_with_method (uri, SOUP_METHOD_GET, NULL);
 }
 
 DexFuture *
@@ -155,38 +159,59 @@ DexFuture *
 bz_query_flathub_v2_json_authenticated (const char *request,
                                         const char *token)
 {
+  g_autofree char *uri = NULL;
+
   dex_return_error_if_fail (request != NULL);
-  return query_flathub_v2_json_with_method (request, SOUP_METHOD_GET, token);
+
+  uri = g_strdup_printf ("https://flathub.org/api/v2%s", request);
+  return query_uri_json_with_method (uri, SOUP_METHOD_GET, token);
 }
 
 DexFuture *
 bz_query_flathub_v2_json_authenticated_post (const char *request,
                                              const char *token)
 {
+  g_autofree char *uri = NULL;
+
   dex_return_error_if_fail (request != NULL);
-  return query_flathub_v2_json_with_method (request, SOUP_METHOD_POST, token);
+
+  uri = g_strdup_printf ("https://flathub.org/api/v2%s", request);
+  return query_uri_json_with_method (uri, SOUP_METHOD_POST, token);
 }
 
 DexFuture *
 bz_query_flathub_v2_json_authenticated_delete (const char *request,
                                                const char *token)
 {
+  g_autofree char *uri = NULL;
+
   dex_return_error_if_fail (request != NULL);
-  return query_flathub_v2_json_with_method (request, SOUP_METHOD_DELETE, token);
+
+  uri = g_strdup_printf ("https://flathub.org/api/v2%s", request);
+  return query_uri_json_with_method (uri, SOUP_METHOD_DELETE, token);
+}
+
+DexFuture *
+bz_query_bazaar_json (const char *request)
+{
+  g_autofree char *uri = NULL;
+
+  dex_return_error_if_fail (request != NULL);
+
+  uri = g_strdup_printf ("https://usebazaar.org%s", request);
+  return query_uri_json_with_method (uri, SOUP_METHOD_GET, NULL);
 }
 
 static DexFuture *
-query_flathub_v2_json_with_method (const char *request,
-                                   const char *method,
-                                   const char *token)
+query_uri_json_with_method (const char *uri,
+                            const char *method,
+                            const char *token)
 {
-  g_autofree char *uri             = NULL;
   g_autoptr (SoupMessage) message  = NULL;
   SoupMessageHeaders *headers      = NULL;
   g_autoptr (GOutputStream) output = NULL;
   g_autoptr (DexFuture) future     = NULL;
 
-  uri     = g_strdup_printf ("https://flathub.org/api/v2%s", request);
   message = soup_message_new (method, uri);
   headers = soup_message_get_request_headers (message);
 

--- a/src/bz-global-net.h
+++ b/src/bz-global-net.h
@@ -56,6 +56,9 @@ DexFuture *
 bz_query_flathub_v2_json_take (char *request);
 
 DexFuture *
+bz_query_bazaar_json (const char *request);
+
+DexFuture *
 bz_fetch_uri_contents (const char *uri);
 
 G_END_DECLS


### PR DESCRIPTION
This PR adds a new section to the full view page showcasing similar apps to the one the user is currently viewing. Making it easier to discover alternative or related apps.

I have added a daily GitHub action to the site that runs a python script. The script first downloads and parses the Flathub appstream bundle, and then tries to find similar apps for each app found via TF-IDF and cosine similarity via solely the apps metadata. It also avoids other apps by the same dev, as the other section already shows that.

<img width="1996" height="1898" alt="image" src="https://github.com/user-attachments/assets/d8a52040-f69c-46bd-ad6b-9fe83a591b82" />
