### PR TITLE
chore: add bz-search-bar.blp to the potfile

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -119,6 +119,7 @@ src/bz-screenshots-carousel.c
 src/bz-search-engine.c
 src/bz-search-filter-popover.blp
 src/bz-search-filter-popover.c
+src/bz-search-bar.blp
 src/bz-search-page.blp
 src/bz-search-page.c
 src/bz-search-pill-list.c


### PR DESCRIPTION
It was missing :+1: 