### PR TITLE
Window: Fix avatar menu button being visible on load

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -162,7 +162,7 @@ template $BzWindow: Adw.ApplicationWindow {
 
                     [start]
                     MenuButton {
-                      visible: bind template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.authenticated;
+                      visible: bind try {template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.authenticated, false};
                       menu-model: account_menu;
 
                       styles [


### PR DESCRIPTION
Since I moved the auth init to the fiber, auth-state would be null for a little bit. Causing the MenuButton visibility expression to fail and return true.