### PR TITLE
Add placeholder size for non loaded screenshots

### DIFF
--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -120,6 +120,8 @@ find_screenshot (GPtrArray  *images,
   const char *best_url      = NULL;
   gint        best_diff     = G_MAXINT;
   guint       best_res      = 0;
+  guint       best_width    = 0;
+  guint       best_height   = 0;
   guint       target_pixels = target_width * target_height;
 
   if (images == NULL)
@@ -143,8 +145,10 @@ find_screenshot (GPtrArray  *images,
         {
           if (best_url == NULL || pixels > best_res)
             {
-              best_url = url;
-              best_res = pixels;
+              best_url    = url;
+              best_res    = pixels;
+              best_width  = width;
+              best_height = height;
             }
         }
       else
@@ -152,8 +156,10 @@ find_screenshot (GPtrArray  *images,
           gint diff = ABS ((gint) pixels - (gint) target_pixels);
           if (best_url == NULL || diff < best_diff)
             {
-              best_url  = url;
-              best_diff = diff;
+              best_url    = url;
+              best_diff   = diff;
+              best_width  = width;
+              best_height = height;
             }
         }
     }
@@ -170,7 +176,10 @@ find_screenshot (GPtrArray  *images,
       cache_file      = g_file_new_build_filename (
           module_dir, unique_id_checksum, cache_filename, NULL);
 
-      texture = bz_async_texture_new_lazy (screenshot_file, cache_file);
+      if (best_width > 0 && best_height > 0)
+        texture = bz_async_texture_new_lazy_with_size (screenshot_file, cache_file, best_width, best_height);
+      else
+        texture = bz_async_texture_new_lazy (screenshot_file, cache_file);
 
       if (out_caption != NULL)
         *out_caption = g_strdup (caption ? caption : "");

--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -98,6 +98,9 @@ struct _BzAsyncTexture
   char    *cache_into_path;
   gboolean lazy;
 
+  int      width;
+  int      height;
+
   DexFuture    *task;
   GCancellable *cancellable;
 
@@ -129,6 +132,13 @@ enum
   LAST_PROP
 };
 static GParamSpec *props[LAST_PROP] = { 0 };
+
+static BzAsyncTexture *
+bz_async_texture_new_internal (GFile   *source,
+                               GFile   *cache_into,
+                               int      width,
+                               int      height,
+                               gboolean lazy);
 
 static DexFuture *
 load_fiber_work (LoadData *data);
@@ -332,7 +342,7 @@ paintable_get_intrinsic_width (GdkPaintable *paintable)
   if (self->paintable != NULL)
     return gdk_paintable_get_intrinsic_width (self->paintable);
 
-  return 0;
+  return self->width;
 }
 
 static int
@@ -347,7 +357,7 @@ paintable_get_intrinsic_height (GdkPaintable *paintable)
   if (self->paintable != NULL)
     return gdk_paintable_get_intrinsic_height (self->paintable);
 
-  return 0;
+  return self->height;
 }
 
 static double
@@ -361,6 +371,9 @@ paintable_get_intrinsic_aspect_ratio (GdkPaintable *paintable)
 
   if (self->paintable != NULL)
     return gdk_paintable_get_intrinsic_aspect_ratio (self->paintable);
+
+  if (self->width > 0 && self->height > 0)
+    return (double) self->width / (double) self->height;
 
   return 0.0;
 }
@@ -376,9 +389,12 @@ paintable_iface_init (GdkPaintableInterface *iface)
   iface->get_intrinsic_aspect_ratio = paintable_get_intrinsic_aspect_ratio;
 }
 
-BzAsyncTexture *
-bz_async_texture_new (GFile *source,
-                      GFile *cache_into)
+static BzAsyncTexture *
+bz_async_texture_new_internal (GFile   *source,
+                               GFile   *cache_into,
+                               int      width,
+                               int      height,
+                               gboolean lazy)
 {
   BzAsyncTexture *self = NULL;
 
@@ -390,29 +406,46 @@ bz_async_texture_new (GFile *source,
   self->source_uri      = g_file_get_uri (source);
   self->cache_into      = bz_object_maybe_ref (cache_into);
   self->cache_into_path = bz_maybe (cache_into, g_file_get_path);
-  self->lazy            = FALSE;
+  self->lazy            = lazy;
+  self->width           = width;
+  self->height          = height;
 
-  maybe_load (self);
+  if (!lazy)
+    maybe_load (self);
+
   return self;
+}
+
+BzAsyncTexture *
+bz_async_texture_new (GFile *source,
+                      GFile *cache_into)
+{
+  return bz_async_texture_new_internal (source, cache_into, 0, 0, FALSE);
+}
+
+BzAsyncTexture *
+bz_async_texture_new_with_size (GFile *source,
+                                GFile *cache_into,
+                                int    width,
+                                int    height)
+{
+  return bz_async_texture_new_internal (source, cache_into, width, height, FALSE);
 }
 
 BzAsyncTexture *
 bz_async_texture_new_lazy (GFile *source,
                            GFile *cache_into)
 {
-  BzAsyncTexture *self = NULL;
+  return bz_async_texture_new_internal (source, cache_into, 0, 0, TRUE);
+}
 
-  g_return_val_if_fail (G_IS_FILE (source), NULL);
-  g_return_val_if_fail (cache_into == NULL || G_IS_FILE (cache_into), NULL);
-
-  self                  = g_object_new (BZ_TYPE_ASYNC_TEXTURE, NULL);
-  self->source          = g_object_ref (source);
-  self->source_uri      = g_file_get_uri (source);
-  self->cache_into      = bz_object_maybe_ref (cache_into);
-  self->cache_into_path = bz_maybe (cache_into, g_file_get_path);
-  self->lazy            = TRUE;
-
-  return self;
+BzAsyncTexture *
+bz_async_texture_new_lazy_with_size (GFile *source,
+                                     GFile *cache_into,
+                                     int    width,
+                                     int    height)
+{
+  return bz_async_texture_new_internal (source, cache_into, width, height, TRUE);
 }
 
 GFile *
@@ -441,6 +474,20 @@ bz_async_texture_get_cache_into_path (BzAsyncTexture *self)
 {
   g_return_val_if_fail (BZ_IS_ASYNC_TEXTURE (self), FALSE);
   return self->cache_into_path;
+}
+
+int
+bz_async_texture_get_width (BzAsyncTexture *self)
+{
+  g_return_val_if_fail (BZ_IS_ASYNC_TEXTURE (self), 0);
+  return self->width;
+}
+
+int
+bz_async_texture_get_height (BzAsyncTexture *self)
+{
+  g_return_val_if_fail (BZ_IS_ASYNC_TEXTURE (self), 0);
+  return self->height;
 }
 
 gboolean

--- a/src/bz-async-texture.h
+++ b/src/bz-async-texture.h
@@ -33,8 +33,20 @@ bz_async_texture_new (GFile *source,
                       GFile *cache_into);
 
 BzAsyncTexture *
+bz_async_texture_new_with_size (GFile *source,
+                                 GFile *cache_into,
+                                 int    width,
+                                 int    height);
+
+BzAsyncTexture *
 bz_async_texture_new_lazy (GFile *source,
                            GFile *cache_into);
+
+BzAsyncTexture *
+bz_async_texture_new_lazy_with_size (GFile *source,
+                                     GFile *cache_into,
+                                     int    width,
+                                     int    height);
 
 GFile *
 bz_async_texture_get_source (BzAsyncTexture *self);
@@ -47,6 +59,12 @@ bz_async_texture_get_cache_into (BzAsyncTexture *self);
 
 const char *
 bz_async_texture_get_cache_into_path (BzAsyncTexture *self);
+
+int
+bz_async_texture_get_width (BzAsyncTexture *self);
+
+int
+bz_async_texture_get_height (BzAsyncTexture *self);
 
 gboolean
 bz_async_texture_get_loaded (BzAsyncTexture *self);

--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -2731,6 +2731,8 @@ maybe_save_paintable (BzEntryPrivate  *priv,
   g_autoptr (GError) local_error = NULL;
   const char *source_uri         = NULL;
   const char *cache_into_path    = NULL;
+  int         width              = 0;
+  int         height             = 0;
   g_autoptr (GdkTexture) texture = NULL;
   g_autoptr (GFile) save_file    = NULL;
   gboolean result                = FALSE;
@@ -2742,6 +2744,9 @@ maybe_save_paintable (BzEntryPrivate  *priv,
 
   source_uri      = bz_async_texture_get_source_uri (BZ_ASYNC_TEXTURE (paintable));
   cache_into_path = bz_async_texture_get_cache_into_path (BZ_ASYNC_TEXTURE (paintable));
+  width           = bz_async_texture_get_width (BZ_ASYNC_TEXTURE (paintable));
+  height          = bz_async_texture_get_height (BZ_ASYNC_TEXTURE (paintable));
+
   if (cache_into_path == NULL)
     goto done;
 
@@ -2810,7 +2815,8 @@ maybe_save_paintable (BzEntryPrivate  *priv,
     }
 
 done:
-  g_variant_builder_add (builder, "{sv}", key, g_variant_new ("(sms)", source_uri, cache_into_path));
+  g_variant_builder_add (builder, "{sv}", key,
+                         g_variant_new ("(smsii)", source_uri, cache_into_path, width, height));
   return TRUE;
 }
 
@@ -2819,16 +2825,22 @@ make_async_texture (GVariant *parse)
 {
   g_autofree char *source            = NULL;
   g_autofree char *cache_into        = NULL;
+  int              width             = 0;
+  int              height            = 0;
   g_autoptr (GFile) source_file      = NULL;
   g_autoptr (GFile) cache_into_file  = NULL;
   g_autoptr (BzAsyncTexture) texture = NULL;
 
-  g_variant_get (parse, "(sms)", &source, &cache_into);
+  g_variant_get (parse, "(smsii)", &source, &cache_into, &width, &height);
   source_file = g_file_new_for_uri (source);
   if (cache_into != NULL)
     cache_into_file = g_file_new_for_path (cache_into);
 
-  texture = bz_async_texture_new_lazy (source_file, cache_into_file);
+  if (width > 0 && height > 0)
+    texture = bz_async_texture_new_lazy_with_size (source_file, cache_into_file, width, height);
+  else
+    texture = bz_async_texture_new_lazy (source_file, cache_into_file);
+
   return GDK_PAINTABLE (g_steal_pointer (&texture));
 }
 


### PR DESCRIPTION
This stops ugly layout shifts in the screenshot carousel, especially noticeable on slower internet connections. It's also especially important for us as we start from the second screenshot.

It's possible that some remotes don't provide width and height in their appstream, but in that scenario it should just fallback to the old behavior.

(I added the red boxes and loading delay for illustrative purposes)
[Screencast From 2026-07-08 10-59-42.webm](https://github.com/user-attachments/assets/48505afc-f48e-414c-8d9b-1055e44a3e51)
