### PR TITLE
Open app page in background when opening add-on via appstream

### DIFF
--- a/src/bz-addons-dialog.c
+++ b/src/bz-addons-dialog.c
@@ -325,6 +325,16 @@ bz_addons_dialog_new_single (BzEntryGroup *group)
   return ADW_DIALOG (self);
 }
 
+BzEntry *
+bz_addons_dialog_get_parent_entry (BzAddonsDialog *self)
+{
+
+  if (self->parent_ui_entry == NULL || !bz_result_get_resolved (self->parent_ui_entry))
+    return NULL;
+
+  return bz_result_get_object (self->parent_ui_entry);
+}
+
 static char *
 format_parent_title (gpointer    object,
                      const char *title)

--- a/src/bz-addons-dialog.c
+++ b/src/bz-addons-dialog.c
@@ -328,6 +328,7 @@ bz_addons_dialog_new_single (BzEntryGroup *group)
 BzEntry *
 bz_addons_dialog_get_parent_entry (BzAddonsDialog *self)
 {
+  g_return_val_if_fail (BZ_IS_ADDONS_DIALOG (self), NULL);
 
   if (self->parent_ui_entry == NULL || !bz_result_get_resolved (self->parent_ui_entry))
     return NULL;

--- a/src/bz-addons-dialog.h
+++ b/src/bz-addons-dialog.h
@@ -35,4 +35,7 @@ bz_addons_dialog_new (BzEntryGroup *group);
 AdwDialog *
 bz_addons_dialog_new_single (BzEntryGroup *group);
 
+BzEntry *
+bz_addons_dialog_get_parent_entry (BzAddonsDialog *self);
+
 G_END_DECLS

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -3814,6 +3814,9 @@ open_generic_id (BzApplication *self,
 
   window = get_or_create_window (self);
 
+  if (adw_application_window_get_visible_dialog (ADW_APPLICATION_WINDOW (window)) != NULL)
+    window = new_window (self);
+
   if (group != NULL)
     {
       gtk_widget_activate_action (GTK_WIDGET (window), "window.show-group", "s", matched_id);

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -478,6 +478,27 @@ action_cancel_group (GtkWidget  *widget,
 }
 
 static void
+parent_ui_entry_show_group_cb (BzAddonsDialog *dialog,
+                               GParamSpec     *pspec,
+                               BzWindow       *self)
+{
+  BzEntry                 *entry = NULL;
+  g_autoptr (BzEntryGroup) group = NULL;
+
+  entry = bz_addons_dialog_get_parent_entry (dialog);
+  if (entry == NULL)
+    return;
+
+  group = bz_application_map_factory_convert_one (
+      bz_state_info_get_application_factory (bz_window_get_state_info (self)),
+      gtk_string_object_new (bz_entry_get_id (entry)));
+  if (group == NULL)
+    return;
+
+  bz_window_show_group (self, group);
+}
+
+static void
 action_show_group (GtkWidget  *widget,
                    const char *action_name,
                    GVariant   *parameter)
@@ -499,6 +520,10 @@ action_show_group (GtkWidget  *widget,
       AdwDialog *dialog = NULL;
 
       dialog = bz_addons_dialog_new_single (group);
+      g_signal_connect_object (dialog, "notify::parent-ui-entry",
+                               G_CALLBACK (parent_ui_entry_show_group_cb),
+                               self, 0);
+      parent_ui_entry_show_group_cb (BZ_ADDONS_DIALOG (dialog), NULL, self);
       adw_dialog_present (dialog, GTK_WIDGET (self));
     }
   else


### PR DESCRIPTION
Also fixes issue where the add-on dialog could spawn on top of another dialog.

I made to choice to bind to the property in the window so it stays clear what action_show_group does exactly.

<img width="2540" height="1900" alt="image" src="https://github.com/user-attachments/assets/3d2fbe87-3c31-49cb-8956-a062edb59cff" />

closes #1709