### PR TITLE
fix(ci): workaround broken caching mechanism upstream

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -45,7 +45,6 @@ jobs:
         key: flatpak-builder-046f9ec-${{ matrix.variant.arch }}-${{ github.run_id }}
         restore-keys: |
           flatpak-builder-046f9ec-${{ matrix.variant.arch }}-
-          flatpak-builder-046f9ec-${{ matrix.variant.arch }}
 
     - name: Build Flatpak
       uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6.7

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -8,6 +8,7 @@ on:
       - "screenshots/*"
       - "translators.sh"
       - ".github/ISSUE_TEMPLATE/**"
+  workflow_dispatch:
 
 name: CI Build Flatpak
 jobs:

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -25,15 +25,40 @@ jobs:
           # no latest for ARM :(
           - arch: aarch64
             runner: ubuntu-24.04-arm
+
     runs-on: ${{ matrix.variant.runner }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Git Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         submodules: recursive
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@92ae9851ad316786193b1fd3f40c4b51eb5cb101 # v6.6
+        persist-credentials: false
+
+    - name: Restore cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .flatpak-builder
+        key: flatpak-builder-046f9ec-${{ matrix.variant.arch }}-${{ github.run_id }}
+        restore-keys: |
+          flatpak-builder-046f9ec-${{ matrix.variant.arch }}-
+          flatpak-builder-046f9ec-${{ matrix.variant.arch }}
+
+    - name: Build Flatpak
+      uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6.7
       with:
         bundle: Bazaar.flatpak
         manifest-path: build-aux/flatpak/io.github.kolunmi.Bazaar.json
-        cache-key: flatpak-builder-046f9ec
+        # caching is broken upstream
+        # https://github.com/flatpak/flatpak-github-actions/issues/239
+        # this is only true because there is no other way to call fb with --ccache
+        cache: true
+        restore-cache: false
         arch: ${{ matrix.variant.arch }}
         verbose: true
+
+    - name: Write new cache
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .flatpak-builder
+        key: flatpak-builder-046f9ec-${{ matrix.variant.arch }}-${{ github.run_id }}

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -10,6 +10,8 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
 
+permissions: {}
+
 name: CI Build Flatpak
 jobs:
 


### PR DESCRIPTION
The short explanation is that we either get a stale cache or never
restore a cache without this. We are hitting the former.

The bad part about this, is that cache is incremental only, but it would
get pruned when it reaches 10G.

I have no idea why bazaar itself is never cached, only the deps for some
reason. The build does not take long anyway, so this change as a whole
is purely for the love of the game.