### PR TITLE
fix(po): Remove src/bz-gnome-shell-search-provider.c

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -73,7 +73,6 @@ src/bz-flatpak-entry.c
 src/bz-flatpak-instance.c
 src/bz-full-view.blp
 src/bz-full-view.c
-src/bz-gnome-shell-search-provider.c
 src/bz-group-tile-css-watcher.c
 src/bz-hardware-support-dialog.blp
 src/bz-hardware-support-dialog.c


### PR DESCRIPTION
It was removed in 3dd1497f42d081dd57ebdff1ccf085836889e687.