### PR TITLE
Add an auto updater

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -70,5 +70,25 @@
       <summary>Check For Ubuntu</summary>
       <description>Whether to check for and warn about Ubuntu's broken apparmor permissions on startup</description>
     </key>
+    <key name="auto-update" type="b">
+      <default>false</default>
+      <summary>Automatic Updates</summary>
+      <description>Whether to auto check for and install app updates in the background</description>
+    </key>
+    <key name="auto-update-notifications" type="b">
+      <default>true</default>
+      <summary>Auto Update Notifications</summary>
+      <description>Show a notification after apps are automatically updated in the background</description>
+    </key>
+    <key name="last-update-check" type="x">
+      <default>0</default>
+      <summary>Last Update Check</summary>
+      <description>Unix timestamp of the last automatic update check</description>
+    </key>
+    <key name="update-check-hour-offset" type="i">
+      <default>-1</default>
+      <summary>Update Check Hour Offset</summary>
+      <description>Randomized hour offset added to the daily update check window, to avoid all clients checking at once</description>
+    </key>
   </schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -94,6 +94,7 @@ else
     config_h.set_quoted('PACKAGE_VERSION', bz_version)
     config_h.set_quoted('PACKAGE_VCS_VERSION', bz_vcs_version)
     config_h.set_quoted('GETTEXT_PACKAGE', 'bazaar')
+    config_h.set_quoted('APPLICATION_ID', 'io.github.kolunmi.Bazaar')
     config_h.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
     config_h.set_quoted('DONATE_LINK', 'https://ko-fi.com/kolunmi')
     config_h.set_quoted('RELEASE_PAGE', run_command('version.sh', 'get-gh-release').stdout().strip())
@@ -101,6 +102,8 @@ else
     bazaar_bin_name = 'bazaar'
     config_h.set_quoted('BAZAAR_BIN_NAME', bazaar_bin_name)
     config_h.set_quoted('REFRESH_WORKER_CLI_OPTION', '--run-refresh-worker')
+
+    config_h.set_quoted('UPDATE_WORKER_CLI_OPTION', '--run-update-worker')
 
     dl_worker_bin_name = 'bazaar-dl-worker'
     config_h.set_quoted('DL_WORKER_BIN_NAME', dl_worker_bin_name)

--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,6 @@ else
     bazaar_bin_name = 'bazaar'
     config_h.set_quoted('BAZAAR_BIN_NAME', bazaar_bin_name)
     config_h.set_quoted('REFRESH_WORKER_CLI_OPTION', '--run-refresh-worker')
-
     config_h.set_quoted('UPDATE_WORKER_CLI_OPTION', '--run-update-worker')
 
     dl_worker_bin_name = 'bazaar-dl-worker'

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -150,3 +150,4 @@ src/io.c
 src/main.c
 src/safety-calculator.c
 src/shortcuts-dialog.blp
+src/update-worker.c

--- a/src/bazaar-daemon.c
+++ b/src/bazaar-daemon.c
@@ -39,6 +39,8 @@
 #define MAX_SEARCH_RESULTS  25
 #define ACTIVATE_TIMEOUT_US 2000000
 
+#define UPDATE_CHECK_INTERVAL_USEC (60ULL * 60ULL * 1000000ULL) /* 1 hour */
+
 #define _cleanup_(x) __attribute__ ((cleanup (x)))
 
 #define SD_BUS_CHECK(expr) \
@@ -50,11 +52,12 @@
     }                      \
   while (0)
 
-static sd_event    *event        = NULL;
-static sd_bus      *bus          = NULL;
-static pid_t        child_pid    = -1;
-static SearchIndex *g_index      = NULL;
-static char        *g_index_path = NULL;
+static sd_event        *event               = NULL;
+static sd_bus          *bus                 = NULL;
+static pid_t            child_pid           = -1;
+static SearchIndex     *g_index             = NULL;
+static char            *g_index_path        = NULL;
+static sd_event_source *update_timer_source = NULL;
 
 static void  log_msg (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 static void *malloc_or_bail (size_t n_bytes);
@@ -66,6 +69,10 @@ static void  strv_freep (char ***strv);
 static void  generic_freep (void *p);
 static int   on_child_exit (sd_event_source *s, const siginfo_t *si, void *userdata);
 static void  launch_app (char **extra_args, int n_extra_args);
+static void  run_update_worker_once (void);
+static int   on_update_worker_exit (sd_event_source *s, const siginfo_t *si, void *userdata);
+static int   on_update_timer (sd_event_source *s, uint64_t usec, void *userdata);
+static int   schedule_next_update_check (void);
 static int   build_and_send_search_reply (sd_bus_message *call, char **terms);
 static int   method_get_result_set (sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
 static int   method_get_result_metas (sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
@@ -156,6 +163,7 @@ main (int argc, char *argv[])
     log_msg ("Failed to attach bus to event loop: %s", strerror (-r));
 
   ensure_index_loaded ();
+  schedule_next_update_check ();
 
   fwd_args = malloc_or_bail (sizeof (char *) * (size_t) (argc > 0 ? argc : 1));
   for (i = 1; i < argc; i++)
@@ -176,6 +184,9 @@ main (int argc, char *argv[])
     launch_app (fwd_args, n_fwd_args);
 
   sd_event_loop (event);
+
+  if (update_timer_source != NULL)
+    sd_event_source_unref (update_timer_source);
 
   search_index_close (g_index);
   free (g_index_path);
@@ -411,6 +422,81 @@ launch_app (char **extra_args,
     child_pid = pid;
 
   sd_event_add_child (event, NULL, pid, WEXITED, on_child_exit, NULL);
+}
+
+static void
+run_update_worker_once (void)
+{
+  pid_t    pid     = -1;
+  char    *argv[3] = { NULL };
+  sigset_t mask    = { 0 };
+
+  argv[0] = (char *) BAZAAR_BIN_PATH;
+  argv[1] = (char *) UPDATE_WORKER_CLI_OPTION;
+  argv[2] = NULL;
+
+  pid = fork ();
+  if (pid == 0)
+    {
+      sigemptyset (&mask);
+      sigprocmask (SIG_SETMASK, &mask, NULL);
+
+      execvp (argv[0], argv);
+      perror ("execvp");
+      _exit (127);
+    }
+
+  if (pid < 0)
+    {
+      log_msg ("Failed to spawn update worker: %s", strerror (errno));
+      return;
+    }
+
+  sd_event_add_child (event, NULL, pid, WEXITED, on_update_worker_exit, NULL);
+}
+
+static int
+on_update_worker_exit (sd_event_source *s,
+                       const siginfo_t *si,
+                       void            *userdata)
+{
+  sd_event_source_unref (s);
+  return 0;
+}
+
+static int
+on_update_timer (sd_event_source *s,
+                 uint64_t         usec,
+                 void            *userdata)
+{
+  run_update_worker_once ();
+  schedule_next_update_check ();
+  return 0;
+}
+
+static int
+schedule_next_update_check (void)
+{
+  uint64_t now = 0;
+  int      r   = 0;
+
+  if (update_timer_source != NULL)
+    {
+      sd_event_source_unref (update_timer_source);
+      update_timer_source = NULL;
+    }
+
+  r = sd_event_now (event, CLOCK_BOOTTIME, &now);
+  if (r < 0)
+    return r;
+
+  r = sd_event_add_time (event, &update_timer_source, CLOCK_BOOTTIME,
+                         now + UPDATE_CHECK_INTERVAL_USEC, 0,
+                         on_update_timer, NULL);
+  if (r < 0)
+    log_msg ("failed to schedule update: %s", strerror (-r));
+
+  return r;
 }
 
 static int

--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -28,26 +28,83 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
     };
 
     Adw.PreferencesGroup {
+      title: _("App Updates");
+
+      [header-suffix]
+      MenuButton {
+        styles ["flat"]
+
+        icon-name: "info-outline-symbolic";
+        popover: Popover {
+          child: Label {
+            max-width-chars: 55;
+            wrap: true;
+            margin-end: 6;
+            margin-top: 6;
+            margin-bottom: 6;
+            margin-start: 6;
+            label: _ ("Checking for and downloading app updates uses data and power. Automatic app update features are therefore paused when on metered network connections and when power saver is on.");
+          };
+        };
+      }
+
+      Adw.ActionRow automatic_updates_row {
+        title: _("_Automatic");
+        subtitle: _("Automatically check for and download app updates");
+        use-underline: true;
+        activatable-widget: automatic_updates_check;
+
+        [prefix]
+        CheckButton automatic_updates_check {}
+      }
+
+      Adw.ActionRow manual_updates_row {
+        title: _("_Manual");
+        subtitle: _("Checking for and downloading app updates must be done manually");
+        use-underline: true;
+        activatable-widget: manual_updates_check;
+
+        [prefix]
+        CheckButton manual_updates_check {
+          active: bind automatic_updates_check.active inverted;
+          group: automatic_updates_check;
+        }
+      }
+    }
+
+    Adw.PreferencesGroup {
+      Adw.SwitchRow auto_notif_switch {
+        use-underline: true;
+        title: _("Automatic Update _Notifications");
+        subtitle: _("Notify when updates have been automatically installed");
+      }
+    }
+
+    Adw.PreferencesGroup {
       title: _("Content Filters");
 
       Adw.SwitchRow only_foss_switch {
-        title: _("Free Software Only");
+        title: _("_Free Software Only");
         subtitle: _("Hide proprietary apps when browsing and searching");
+        use-underline: true;
       }
 
       Adw.SwitchRow only_flathub_switch {
-        title: _("Flathub Results Only");
+        title: _("F_lathub Results Only");
         subtitle: _("Limit search and browse results to apps only available on Flathub");
+        use-underline: true;
       }
 
       Adw.SwitchRow only_verified_switch {
-        title: _("Verified Results Only");
+        title: _("_Verified Results Only");
         subtitle: _("Hide results that are not verified on Flathub");
+        use-underline: true;
       }
 
       Adw.SwitchRow hide_eol_switch {
-        title: _("Hide End-of-Life Apps");
+        title: _("Hide _End-of-Life Apps");
         subtitle: _("Hide apps which are no longer supported by their developers");
+        use-underline: true;
       }
     }
 

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -61,11 +61,13 @@ struct _BzPreferencesDialog
   GSettings   *settings;
 
   /* Template widgets */
-  AdwSwitchRow *only_foss_switch;
-  AdwSwitchRow *only_flathub_switch;
-  AdwSwitchRow *only_verified_switch;
-  GtkFlowBox   *flag_buttons_box;
-  AdwSwitchRow *hide_eol_switch;
+  GtkCheckButton *automatic_updates_check;
+  AdwSwitchRow   *auto_notif_switch;
+  AdwSwitchRow   *only_foss_switch;
+  AdwSwitchRow   *only_flathub_switch;
+  AdwSwitchRow   *only_verified_switch;
+  GtkFlowBox     *flag_buttons_box;
+  AdwSwitchRow   *hide_eol_switch;
 
   GtkToggleButton *flag_buttons[G_N_ELEMENTS (bar_themes)];
 };
@@ -191,6 +193,14 @@ bind_settings (BzPreferencesDialog *self)
                    self->hide_eol_switch, "active",
                    G_SETTINGS_BIND_DEFAULT);
 
+  g_settings_bind (self->settings, "auto-update",
+                 self->automatic_updates_check, "active",
+                 G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (self->settings, "auto-update-notifications",
+                   self->auto_notif_switch, "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
   g_signal_connect_object (
       self->settings,
       "changed::global-progress-bar-theme",
@@ -264,6 +274,8 @@ bz_preferences_dialog_class_init (BzPreferencesDialogClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, only_verified_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, flag_buttons_box);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, hide_eol_switch);
+  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, automatic_updates_check);
+  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, auto_notif_switch);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 
 #include "bz-application.h"
 #include "refresh-worker.h"
+#include "update-worker.h"
 
 int
 main (int   argc,
@@ -52,13 +53,15 @@ main (int   argc,
 
   if (argc > 1 && g_strcmp0 (argv[1], REFRESH_WORKER_CLI_OPTION) == 0)
     result = run_refresh_worker (argc, argv);
+  else if (argc > 1 && g_strcmp0 (argv[1], UPDATE_WORKER_CLI_OPTION) == 0)
+    result = run_update_worker (argc, argv);
   else
     {
       g_autoptr (BzApplication) app = NULL;
 
       app = g_object_new (
           BZ_TYPE_APPLICATION,
-          "application-id", "io.github.kolunmi.Bazaar",
+          "application-id", APPLICATION_ID,
           "flags", G_APPLICATION_HANDLES_COMMAND_LINE,
           "resource-base-path", "/io/github/kolunmi/Bazaar",
           NULL);

--- a/src/meson.build
+++ b/src/meson.build
@@ -174,6 +174,7 @@ bz_sources = files(
   'search-index-write.c',
   'spdx.c',
   'template-callbacks.c',
+  'update-worker.c',
 )
 subdir('progress-bar-designs')
 

--- a/src/update-worker.c
+++ b/src/update-worker.c
@@ -1,0 +1,386 @@
+/* update-worker.c
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#define G_LOG_DOMAIN "BAZAAR::UPDATE-WORKER"
+
+#include "config.h"
+
+#include <flatpak/flatpak.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gi18n.h>
+
+#include "update-worker.h"
+
+#define DAILY_WINDOW_START_HOUR   6
+#define DAILY_WINDOW_SPREAD_HOURS 6
+
+static gboolean network_is_metered (void);
+static gboolean power_saver_is_enabled (void);
+static gboolean due_for_daily_check (GSettings *settings);
+static gboolean should_skip_extension_ref (FlatpakInstalledRef *iref);
+static gboolean on_operation_error (FlatpakTransaction          *transaction,
+                                    FlatpakTransactionOperation *operation,
+                                    GError                      *error,
+                                    int                          details,
+                                    gpointer                     user_data);
+static void     update_installation (FlatpakInstallation *installation,
+                                     GHashTable          *titles_out);
+static void     send_update_notification (GHashTable *titles);
+
+int
+run_update_worker (int   argc,
+                   char *argv[])
+{
+  g_autoptr (GSettings) settings              = NULL;
+  g_autoptr (GError) local_error              = NULL;
+  g_autoptr (FlatpakInstallation) system_inst = NULL;
+  g_autoptr (GHashTable) titles               = NULL;
+  gboolean auto_update                        = FALSE;
+  gboolean auto_update_notifications          = FALSE;
+  g_autoptr (GDateTime) now                   = NULL;
+
+  settings                  = g_settings_new (APPLICATION_ID);
+  auto_update               = g_settings_get_boolean (settings, "auto-update");
+  auto_update_notifications = g_settings_get_boolean (settings, "auto-update-notifications");
+
+  if (!auto_update)
+    {
+      g_debug ("Skipping update check: auto-update is disabled\n");
+      return EXIT_SUCCESS;
+    }
+
+  if (!due_for_daily_check (settings))
+    return EXIT_SUCCESS;
+
+  if (network_is_metered ())
+    {
+      g_debug ("Skipping update check: network is metered\n");
+      return EXIT_SUCCESS;
+    }
+
+  if (power_saver_is_enabled ())
+    {
+      g_debug ("Skipping update check: power saver is enabled\n");
+      return EXIT_SUCCESS;
+    }
+
+  titles = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  system_inst = flatpak_installation_new_system (NULL, &local_error);
+  if (system_inst == NULL)
+    {
+      g_warning ("Failed to open system installation: %s", local_error->message);
+      g_clear_error (&local_error);
+    }
+  else
+    {
+      flatpak_installation_set_no_interaction (system_inst, TRUE);
+      update_installation (system_inst, titles);
+    }
+
+#ifndef SANDBOXED_LIBFLATPAK
+  {
+    g_autoptr (FlatpakInstallation) user_inst = NULL;
+
+    user_inst = flatpak_installation_new_user (NULL, &local_error);
+    if (user_inst == NULL)
+      {
+        g_warning ("Failed to open user installation: %s", local_error->message);
+        g_clear_error (&local_error);
+      }
+    else
+      {
+        flatpak_installation_set_no_interaction (user_inst, TRUE);
+        update_installation (user_inst, titles);
+      }
+  }
+#endif
+
+  now = g_date_time_new_now_local ();
+  g_settings_set_int64 (settings, "last-update-check", g_date_time_to_unix (now));
+
+  if (g_hash_table_size (titles) == 0)
+    {
+      g_print ("No apps needed auto updating\n");
+      return EXIT_SUCCESS;
+    }
+
+  if (auto_update_notifications)
+    send_update_notification (titles);
+
+  return EXIT_SUCCESS;
+}
+
+/*
+ * Updates try to run once per day at a randomized hour between 6:00 and
+ * 11:00 local time, to avoid every client updating at once. If more than a
+ * day has passed since the last check then the randomization is skipped and
+ * the check runs as soon as it's past 6:00.
+ *
+ * This logic is copied from GNOME Software.
+ */
+static gboolean
+due_for_daily_check (GSettings *settings)
+{
+  gint64 last_check_unix        = 0;
+  gint   hour_offset            = 0;
+  g_autoptr (GDateTime) now     = NULL;
+  g_autoptr (GDateTime) now_mid = NULL;
+  gint      now_hour            = 0;
+  gint      year = 0, month = 0, day = 0;
+  GTimeSpan day_interval = 0;
+
+  last_check_unix = g_settings_get_int64 (settings, "last-update-check");
+  hour_offset     = g_settings_get_int (settings, "update-check-hour-offset");
+
+  if (hour_offset < 0)
+    {
+      hour_offset = g_random_int_range (0, DAILY_WINDOW_SPREAD_HOURS);
+      g_settings_set_int (settings, "update-check-hour-offset", hour_offset);
+    }
+
+  now = g_date_time_new_now_local ();
+
+  if (last_check_unix == 0)
+    return TRUE;
+
+  {
+    g_autoptr (GDateTime) last_check     = NULL;
+    g_autoptr (GDateTime) last_check_mid = NULL;
+
+    last_check = g_date_time_new_from_unix_local (last_check_unix);
+    if (last_check == NULL)
+      return TRUE;
+
+    g_date_time_get_ymd (last_check, &year, &month, &day);
+    last_check_mid = g_date_time_new_local (year, month, day, 0, 0, 0);
+
+    g_date_time_get_ymd (now, &year, &month, &day);
+    now_mid = g_date_time_new_local (year, month, day, 0, 0, 0);
+
+    day_interval = g_date_time_difference (now_mid, last_check_mid);
+  }
+
+  if (day_interval < G_TIME_SPAN_DAY)
+    {
+      g_debug ("Skipping update check: already checked today\n");
+      return FALSE;
+    }
+
+  now_hour = g_date_time_get_hour (now);
+
+  if (day_interval < 2 * G_TIME_SPAN_DAY &&
+      now_hour < DAILY_WINDOW_START_HOUR + hour_offset)
+    {
+      g_debug ("Skipping update check: too early in the day\n");
+      return FALSE;
+    }
+
+  if (day_interval >= 2 * G_TIME_SPAN_DAY &&
+      now_hour < DAILY_WINDOW_START_HOUR)
+    {
+      g_debug ("Skipping update check: too early in the day\n");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+network_is_metered (void)
+{
+  GNetworkMonitor *monitor = NULL;
+
+  monitor = g_network_monitor_get_default ();
+  if (monitor == NULL)
+    return FALSE;
+
+  return g_network_monitor_get_network_metered (monitor);
+}
+
+static gboolean
+power_saver_is_enabled (void)
+{
+  g_autoptr (GPowerProfileMonitor) monitor = NULL;
+
+  monitor = g_power_profile_monitor_dup_default ();
+  if (monitor == NULL)
+    return FALSE;
+
+  return g_power_profile_monitor_get_power_saver_enabled (monitor);
+}
+
+static gboolean
+should_skip_extension_ref (FlatpakInstalledRef *iref)
+{
+  const char *ref_name = NULL;
+
+  ref_name = flatpak_ref_get_name (FLATPAK_REF (iref));
+
+  return g_str_has_suffix (ref_name, ".Locale") ||
+         g_str_has_suffix (ref_name, ".Debug") ||
+         g_str_has_suffix (ref_name, ".Sources");
+}
+
+static gboolean
+on_operation_error (FlatpakTransaction          *transaction,
+                    FlatpakTransactionOperation *operation,
+                    GError                      *error,
+                    int                          details,
+                    gpointer                     user_data)
+{
+  const char *ref = NULL;
+
+  ref = flatpak_transaction_operation_get_ref (operation);
+
+  g_warning ("Update failed for %s: %s", ref, error->message);
+
+  return TRUE;
+}
+
+static void
+update_installation (FlatpakInstallation *installation,
+                     GHashTable          *titles_out)
+{
+  g_autoptr (GError) local_error             = NULL;
+  g_autoptr (GPtrArray) update_refs          = NULL;
+  g_autoptr (FlatpakTransaction) transaction = NULL;
+  gboolean added_any                         = FALSE;
+  gboolean ran                               = FALSE;
+
+  update_refs = flatpak_installation_list_installed_refs_for_update (
+      installation, NULL, &local_error);
+  if (update_refs == NULL)
+    {
+      g_warning ("Failed to list updates: %s", local_error->message);
+      return;
+    }
+
+  if (update_refs->len == 0)
+    return;
+
+  transaction = flatpak_transaction_new_for_installation (installation, NULL, &local_error);
+  if (transaction == NULL)
+    {
+      g_warning ("Failed to create transaction: %s", local_error->message);
+      return;
+    }
+
+  g_signal_connect (transaction, "operation-error", G_CALLBACK (on_operation_error), NULL);
+
+  for (guint i = 0; i < update_refs->len; i++)
+    {
+      FlatpakInstalledRef *iref    = NULL;
+      g_autofree char     *ref_fmt = NULL;
+      const char          *title   = NULL;
+
+      iref = g_ptr_array_index (update_refs, i);
+      if (should_skip_extension_ref (iref))
+        continue;
+
+      ref_fmt = flatpak_ref_format_ref (FLATPAK_REF (iref));
+
+      title = flatpak_installed_ref_get_appdata_name (iref);
+      if (title == NULL)
+        title = flatpak_ref_get_name (FLATPAK_REF (iref));
+
+      g_hash_table_replace (titles_out, g_strdup (ref_fmt), g_strdup (title));
+
+      if (flatpak_transaction_add_update (transaction, ref_fmt, NULL, NULL, &local_error))
+        added_any = TRUE;
+      else
+        {
+          g_warning ("Failed to queue update for %s: %s", ref_fmt, local_error->message);
+          g_clear_error (&local_error);
+        }
+    }
+
+  if (!added_any)
+    return;
+
+  ran = flatpak_transaction_run (transaction, NULL, &local_error);
+  if (!ran && local_error != NULL)
+    g_warning ("Transaction did not complete cleanly: %s", local_error->message);
+}
+
+static void
+send_update_notification (GHashTable *titles)
+{
+  g_autoptr (GDBusConnection) conn = NULL;
+  g_autoptr (GError) error         = NULL;
+  g_autoptr (GString) body         = NULL;
+  g_autoptr (GPtrArray) updated    = NULL;
+  g_autofree char *summary         = NULL;
+  GVariantBuilder  notification    = { 0 };
+  GHashTableIter   iter            = { 0 };
+  gpointer         ref_key         = NULL;
+  gpointer         title_val       = NULL;
+  guint            n_updated       = 0;
+
+  body    = g_string_new (NULL);
+  updated = g_ptr_array_new ();
+
+  g_hash_table_iter_init (&iter, titles);
+  while (g_hash_table_iter_next (&iter, &ref_key, &title_val))
+    g_ptr_array_add (updated, title_val);
+
+  n_updated = updated->len;
+  if (n_updated == 0)
+    return;
+
+  conn = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
+  if (conn == NULL)
+    {
+      g_warning ("Unable to reach session bus for update notification: %s",
+                 error->message);
+      return;
+    }
+
+  summary = g_strdup_printf (
+      ngettext ("%u App Updated", "%u Apps Updated", n_updated), n_updated);
+
+  if (n_updated == 1)
+    g_string_append_printf (body, _ ("%s has been updated."),
+                            (const char *) g_ptr_array_index (updated, 0));
+  else if (n_updated == 2)
+    g_string_append_printf (body, _ ("%s and %s have been updated."),
+                            (const char *) g_ptr_array_index (updated, 0),
+                            (const char *) g_ptr_array_index (updated, 1));
+  else if (n_updated >= 3)
+    g_string_append_printf (body, _ ("Includes %s, %s and %s."),
+                            (const char *) g_ptr_array_index (updated, 0),
+                            (const char *) g_ptr_array_index (updated, 1),
+                            (const char *) g_ptr_array_index (updated, 2));
+
+  g_variant_builder_init (&notification, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&notification, "{sv}", "title", g_variant_new_string (summary));
+  g_variant_builder_add (&notification, "{sv}", "body", g_variant_new_string (body->str));
+  g_variant_builder_add (&notification, "{sv}", "priority", g_variant_new_string ("normal"));
+
+  g_dbus_connection_call_sync (
+      conn, "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop",
+      "org.freedesktop.portal.Notification", "AddNotification",
+      g_variant_new ("(sa{sv})", "bazaar-update", &notification),
+      NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+
+  if (error != NULL)
+    g_warning ("Failed to send update notification: %s", error->message);
+}

--- a/src/update-worker.h
+++ b/src/update-worker.h
@@ -1,0 +1,31 @@
+/* update-worker.h
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+int
+run_update_worker (int   argc,
+                   char *argv[]);
+
+G_END_DECLS


### PR DESCRIPTION
The auto updater is disabled by default, to not interfere with the auto updaters of ublue or some other app store. Even if running 2 auto updaters probably won't cause any actual issues.

The logic for when to update is the same as in GNOME Software, except it does not check for GameMode and the random hour offset is only set once.

I chose to not re use any backend code from the Flatpak instance, as the update logic is fairly small, dissimilar and does also not need regression testing whenever we change that code.

<img width="1958" height="1866" alt="image" src="https://github.com/user-attachments/assets/08337e18-a189-45ca-9a64-171df8cf44c3" />
