### PR TITLE
Improve desktop entry searchability

### DIFF
--- a/data/io.github.kolunmi.Bazaar.desktop.in
+++ b/data/io.github.kolunmi.Bazaar.desktop.in
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Bazaar
+GenericName=App Store
 Comment=Add, remove or update flatpak software on this computer
 Exec=bazaar-daemon %U
 Icon=io.github.kolunmi.Bazaar
 Terminal=false
 Type=Application
-Categories=Utility;
-Keywords=GTK;System;PackageManager;Discover;Flatpak;Software;Store;
+Categories=GTK;Utility;
+Keywords=System;Package;Manager;Discover;Flatpak;Software;App;Store;
 StartupNotify=true
 MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak;x-scheme-handler/flatpak+https;application/vnd.flatpak;application/vnd.flatpak.ref;
 Actions=new-window;


### PR DESCRIPTION
Adds a GenericName and clearer Keywords to the desktop entry so Bazaar shows up when searching for terms like `Store` or `Package` in app launchers. This should also help with localized searches via GenericName (closes #1585).