### PR TITLE
Handle EOL-rebasing

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1844,32 +1844,40 @@ respond_to_flatpak_fiber (RespondToFlatpakData *data)
                 }
                 break;
               case BZ_BACKEND_NOTIFICATION_KIND_UPDATE_DONE:
-                {
-                  const char *version = NULL;
-
-                  version = bz_backend_notification_get_version (notif);
-                  g_hash_table_replace (self->installed_set, g_strdup (unique_id), g_strdup (version));
-                }
-                break;
               case BZ_BACKEND_NOTIFICATION_KIND_REMOVE_DONE:
                 {
-                  bz_entry_set_installed_version (entry, NULL);
-                  bz_entry_set_installed (entry, FALSE);
-                  g_hash_table_remove (self->installed_set, unique_id);
+                  gboolean was_rebased = FALSE;
 
-                  if (bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_APPLICATION))
+                  was_rebased = bz_backend_notification_get_was_rebased (notif);
+                  if (kind == BZ_BACKEND_NOTIFICATION_KIND_UPDATE_DONE)
                     {
-                      BzEntryGroup *group = NULL;
+                      const char *version = NULL;
 
-                      group = g_hash_table_lookup (self->ids_to_groups, bz_entry_get_id (entry));
-                      if (group != NULL && !bz_entry_group_get_removable (group))
+                      version = bz_backend_notification_get_version (notif);
+                      g_hash_table_replace (self->installed_set, g_strdup (unique_id), g_strdup (version));
+                    }
+
+                  if (kind == BZ_BACKEND_NOTIFICATION_KIND_REMOVE_DONE || was_rebased)
+                    {
+                      bz_entry_set_installed_version (entry, NULL);
+                      bz_entry_set_installed (entry, FALSE);
+                      g_hash_table_remove (self->installed_set, unique_id);
+
+                      if (bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_APPLICATION))
                         {
-                          gboolean found    = FALSE;
-                          guint    position = 0;
+                          BzEntryGroup *group = NULL;
 
-                          found = g_list_store_find (self->installed_apps, group, &position);
-                          if (found)
-                            g_list_store_remove (self->installed_apps, position);
+                          group = g_hash_table_lookup (self->ids_to_groups, bz_entry_get_id (entry));
+                          if (group != NULL &&
+                              (was_rebased || !bz_entry_group_get_removable (group)))
+                            {
+                              gboolean found    = FALSE;
+                              guint    position = 0;
+
+                              found = g_list_store_find (self->installed_apps, group, &position);
+                              if (found)
+                                g_list_store_remove (self->installed_apps, position);
+                            }
                         }
                     }
                 }

--- a/src/bz-backend-notification.txt
+++ b/src/bz-backend-notification.txt
@@ -16,3 +16,4 @@ property=version char G_TYPE_STRING string
 property=remote_name char G_TYPE_STRING string
 property=generic_id char G_TYPE_STRING string
 property=unique_id char G_TYPE_STRING string
+property=was_rebased gboolean G_TYPE_BOOLEAN boolean

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -30,13 +30,13 @@
 #include "bz-backend-transaction-op-payload.h"
 #include "bz-backend-transaction-op-progress-payload.h"
 #include "bz-backend.h"
-#include "env.h"
 #include "bz-flatpak-bundle-result.h"
 #include "bz-flatpak-private.h"
 #include "bz-flatpak-repo.h"
+#include "bz-repository.h"
+#include "env.h"
 #include "global-net.h"
 #include "io.h"
-#include "bz-repository.h"
 #include "util.h"
 
 /* clang-format off */
@@ -209,6 +209,7 @@ BZ_DEFINE_DATA (
       GPtrArray    *send_futures;
       GHashTable   *ref_to_entry_hash;
       GHashTable   *op_to_progress_hash;
+      GHashTable   *rebased_refs;
       guint         unidentified_op_cnt;
     },
     BZ_RELEASE_DATA (self, bz_weak_release);
@@ -220,7 +221,8 @@ BZ_DEFINE_DATA (
     BZ_RELEASE_DATA (channel, dex_unref);
     BZ_RELEASE_DATA (send_futures, g_ptr_array_unref);
     BZ_RELEASE_DATA (ref_to_entry_hash, g_hash_table_unref);
-    BZ_RELEASE_DATA (op_to_progress_hash, g_hash_table_unref));
+    BZ_RELEASE_DATA (op_to_progress_hash, g_hash_table_unref)
+        BZ_RELEASE_DATA (rebased_refs, g_hash_table_unref));
 static DexFuture *
 transaction_fiber (TransactionData *data);
 
@@ -583,6 +585,7 @@ bz_flatpak_instance_schedule_transaction (BzBackend    *backend,
   data->send_futures        = g_ptr_array_new_with_free_func (dex_unref);
   data->ref_to_entry_hash   = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   data->op_to_progress_hash = g_hash_table_new_full (g_direct_hash, g_direct_equal, g_object_unref, NULL);
+  data->rebased_refs        = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   g_mutex_init (&data->mutex);
 
   return dex_scheduler_spawn (
@@ -2367,10 +2370,14 @@ transaction_fiber (TransactionData *data)
 
       for (guint i = 0; i < updates->len; i++)
         {
-          BzFlatpakEntry  *entry   = NULL;
-          FlatpakRef      *ref     = NULL;
-          gboolean         is_user = FALSE;
-          g_autofree char *ref_fmt = NULL;
+          BzFlatpakEntry      *entry             = NULL;
+          FlatpakRef          *ref               = NULL;
+          gboolean             is_user           = FALSE;
+          g_autofree char     *ref_fmt           = NULL;
+          FlatpakInstallation *installation      = NULL;
+          g_autoptr (FlatpakInstalledRef) iref   = NULL;
+          const char         *eol_rebase         = NULL;
+          FlatpakTransaction *target_transaction = NULL;
 
           entry   = g_ptr_array_index (updates, i);
           ref     = bz_flatpak_entry_get_ref (entry);
@@ -2388,6 +2395,8 @@ transaction_fiber (TransactionData *data)
                   "because its installation couldn't be found",
                   ref_fmt);
             }
+
+          installation = is_user ? self->user : self->system;
 
           if (is_user && user_transaction == NULL)
             user_transaction = flatpak_transaction_new_for_installation (
@@ -2413,14 +2422,47 @@ transaction_fiber (TransactionData *data)
           /* Put updates in one transaction to prevent dependency
              race-conditions, since the update list is most likely coming from
              this instance */
-          result = flatpak_transaction_add_update (
-              is_user
-                  ? user_transaction
-                  : sys_transaction,
-              ref_fmt,
-              NULL,
-              NULL,
-              &local_error);
+          target_transaction = is_user ? user_transaction : sys_transaction;
+
+          iref = flatpak_installation_get_installed_ref (
+              installation,
+              flatpak_ref_get_kind (ref),
+              flatpak_ref_get_name (ref),
+              flatpak_ref_get_arch (ref),
+              flatpak_ref_get_branch (ref),
+              cancellable,
+              NULL);
+
+          if (iref != NULL)
+            eol_rebase = flatpak_installed_ref_get_eol_rebase (iref);
+
+          if (eol_rebase != NULL)
+            {
+              const char        *origin               = NULL;
+              static const char *empty_previous_ids[] = { NULL };
+
+              origin = flatpak_installed_ref_get_origin (iref);
+
+              g_debug ("%s is end-of-life, rebasing to %s instead of updating",
+                       ref_fmt, eol_rebase);
+              g_hash_table_add (data->rebased_refs, g_strdup (ref_fmt));
+
+#if FLATPAK_CHECK_VERSION(1, 15, 6)
+              result = flatpak_transaction_add_rebase_and_uninstall (
+                  target_transaction, origin, eol_rebase, ref_fmt,
+                  NULL, empty_previous_ids, &local_error);
+#else
+              result = flatpak_transaction_add_rebase (
+                           target_transaction, origin, eol_rebase,
+                           NULL, NULL, &local_error) &&
+                       flatpak_transaction_add_uninstall (
+                           target_transaction, ref_fmt, &local_error);
+#endif
+            }
+          else
+            result = flatpak_transaction_add_update (
+                target_transaction, ref_fmt, NULL, NULL, &local_error);
+
           if (!result)
             {
               dex_channel_close_send (channel);
@@ -2976,6 +3018,7 @@ transaction_operation_done_fiber (TransactionOperationDoneData *data)
   gboolean                        is_user      = FALSE;
   g_autofree char                *unique_id    = NULL;
   const char                     *version      = NULL;
+  gboolean                        was_rebased  = FALSE;
   FlatpakInstallation            *installation = NULL;
   g_autoptr (FlatpakInstalledRef) iref         = NULL;
   g_autoptr (FlatpakRef) parsed_ref            = NULL;
@@ -3006,7 +3049,8 @@ transaction_operation_done_fiber (TransactionOperationDoneData *data)
   ref     = flatpak_transaction_operation_get_ref (operation);
   is_user = installation == self->user_interactive;
 
-  unique_id = bz_flatpak_ref_parts_format_unique (origin, ref, is_user);
+  unique_id   = bz_flatpak_ref_parts_format_unique (origin, ref, is_user);
+  was_rebased = g_hash_table_contains (data->parent->rebased_refs, ref);
 
   if (op_type == FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE)
     {
@@ -3086,6 +3130,7 @@ transaction_operation_done_fiber (TransactionOperationDoneData *data)
     notif = bz_backend_notification_new ();
     bz_backend_notification_set_kind (notif, notif_kind);
     bz_backend_notification_set_unique_id (notif, unique_id);
+    bz_backend_notification_set_was_rebased (notif, was_rebased);
 
     if (version != NULL && *version != '\0')
       bz_backend_notification_set_version (notif, version);

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -222,7 +222,7 @@ BZ_DEFINE_DATA (
     BZ_RELEASE_DATA (send_futures, g_ptr_array_unref);
     BZ_RELEASE_DATA (ref_to_entry_hash, g_hash_table_unref);
     BZ_RELEASE_DATA (op_to_progress_hash, g_hash_table_unref)
-        BZ_RELEASE_DATA (rebased_refs, g_hash_table_unref));
+    BZ_RELEASE_DATA (rebased_refs, g_hash_table_unref));
 static DexFuture *
 transaction_fiber (TransactionData *data);
 


### PR DESCRIPTION
Handles EOL rebasing as a kind of special case of updates, like GS seems to do. Flatpak seems to also return apps that need to be rebased as updatable.

The core part is just a different Flatpak API call, but we also need some plumbing to handle the removal of the old app from the installed app list.

You can use `flatpak install dev.bragefuglseth.Keypunch` to check it out in action, just make sure to say no to the prompt were it asks to install the new version instead.