### PR TITLE
Add translators notes & remove unneeded strings

### DIFF
--- a/src/bz-bundle-install-dialog.blp
+++ b/src/bz-bundle-install-dialog.blp
@@ -434,6 +434,7 @@ template $BzBundleInstallDialog: Adw.Dialog {
                       ]
 
                       halign: fill;
+                      // TRANSLATORS: Button to launch an installed app
                       label: _("Open");
                       clicked => $run_cb(template);
                     }
@@ -519,6 +520,7 @@ template $BzBundleInstallDialog: Adw.Dialog {
                   ]
 
                   halign: fill;
+                  // TRANSLATORS: Button to launch an installed app
                   label: _("Open");
                   clicked => $run_cb(template);
                 }

--- a/src/bz-curated-view.blp
+++ b/src/bz-curated-view.blp
@@ -21,7 +21,6 @@ template $BzCuratedView: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "empty";
-        title: _("Empty");
 
         child: Adw.StatusPage {
           icon-name: "star-outline-rounded-symbolic";
@@ -44,7 +43,6 @@ template $BzCuratedView: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "offline";
-        title: _("Offline");
 
         child: Adw.StatusPage {
           icon-name: "connected-squares-x";
@@ -54,7 +52,6 @@ template $BzCuratedView: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "content";
-        title: _("Browser");
 
         child: ScrolledWindow {
           hscrollbar-policy: never;

--- a/src/bz-error-dialog.blp
+++ b/src/bz-error-dialog.blp
@@ -44,6 +44,7 @@ template $BzErrorDialog: Adw.Dialog {
 
           Button copy_button {
             icon-name: "edit-copy-symbolic";
+            // TRANSLATORS: tooltip for a button that copies text to the clipboard
             tooltip-text: _("Copy");
             clicked => $on_copy_button_clicked();
 

--- a/src/bz-favorites-page.blp
+++ b/src/bz-favorites-page.blp
@@ -31,7 +31,6 @@ template $BzFavoritesPage: Adw.NavigationPage {
 
         Adw.ViewStackPage {
           name: "loading";
-          title: _("Loading");
           child: Adw.Spinner {
             halign: fill;
             valign: center;
@@ -43,7 +42,6 @@ template $BzFavoritesPage: Adw.NavigationPage {
 
         Adw.ViewStackPage {
           name: "empty";
-          title: _("Empty");
           child: Adw.StatusPage {
             icon-name: "starred-symbolic";
             title: _("No Favorites");
@@ -53,7 +51,6 @@ template $BzFavoritesPage: Adw.NavigationPage {
 
         Adw.ViewStackPage {
           name: "content";
-          title: _("Favorites");
           child: ScrolledWindow {
             hscrollbar-policy: never;
             child: Adw.ClampScrollable {

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -16,7 +16,6 @@ template $BzFlathubPage: Adw.Bin {
 
         Adw.ViewStackPage {
           name: "empty";
-          title: _("Empty");
 
           child: Adw.StatusPage {
             icon-name: "flathub-symbolic";
@@ -27,7 +26,6 @@ template $BzFlathubPage: Adw.Bin {
 
         Adw.ViewStackPage {
           name: "offline";
-          title: _("Flathub Unavailable");
 
           child: Adw.StatusPage {
             icon-name: "connected-squares-x";
@@ -58,7 +56,6 @@ template $BzFlathubPage: Adw.Bin {
 
         Adw.ViewStackPage {
           name: "content";
-          title: _("Browser");
 
           child: ScrolledWindow {
             styles [

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -27,7 +27,6 @@ template $BzFullView: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "empty";
-        title: _("Empty");
 
         child: Adw.StatusPage {
           icon-name: "sad-computer-symbolic";
@@ -38,13 +37,11 @@ template $BzFullView: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "loading";
-        title: _("Empty");
         child: Adw.Bin {};
       }
 
       Adw.ViewStackPage {
         name: "content";
-        title: _("Content");
 
         child: Adw.BreakpointBin {
           width-request: 360;

--- a/src/bz-library-page.blp
+++ b/src/bz-library-page.blp
@@ -26,7 +26,6 @@ template $BzLibraryPage: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "empty";
-        title: _("Empty");
 
         child: Adw.StatusPage {
           icon-name: "library-symbolic";
@@ -37,11 +36,9 @@ template $BzLibraryPage: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "no-results";
-        title: _("No Results");
 
         child: Adw.StatusPage {
           icon-name: "library-symbolic";
-          title: _("No Results");
           description: bind $no_results_found_subtitle(search_bar.text) as <string>;
 
           child: Button {
@@ -58,8 +55,6 @@ template $BzLibraryPage: Adw.Bin {
 
       Adw.ViewStackPage {
         name: "content";
-        // Translators: .
-        title: _("Library");
 
         child: ScrolledWindow scroll{
           hscrollbar-policy: never;

--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -195,7 +195,7 @@ template $BzRichAppTile: $BzListTile {
             styles [
               "medium-pill",
             ]
-
+            // TRANSLATORS: Button to launch an installed app
             label: _("Open");
             valign: center;
             clicked => $run_button_clicked_cb(template);

--- a/src/bz-stats-dialog.blp
+++ b/src/bz-stats-dialog.blp
@@ -24,6 +24,7 @@ template $BzStatsDialog: Adw.BreakpointBin {
 
         Adw.ViewStackPage {
           name: "graph";
+          // TRANSLATORS: page in the statistics dialog
           title: _("Timeline");
           icon-name: "graph2-symbolic";
           visible: bind $model_has_enough_points(template.model) as <bool>;
@@ -43,6 +44,7 @@ template $BzStatsDialog: Adw.BreakpointBin {
 
             $BzDataGraph graph {
               model: bind template.model;
+              // TRANSLATORS: label prefix shown in graph tooltips, for example: "Installs: 42"
               tooltip-prefix: _("Installs:");
               vexpand: true;
               hexpand: true;
@@ -52,6 +54,7 @@ template $BzStatsDialog: Adw.BreakpointBin {
 
         Adw.ViewStackPage {
           name: "map";
+          // TRANSLATORS: page in the statistics dialog
           title: _("World");
           icon-name: "globe-symbolic";
 

--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -295,6 +295,7 @@ template $BzTransactionTile: $BzListTile {
                           ) as <bool>;
 
             valign: center;
+            // TRANSLATORS: Button to launch an installed app
             label: _("Open");
             clicked => $run_cb(template);
 

--- a/src/bz-user-data-page.blp
+++ b/src/bz-user-data-page.blp
@@ -14,7 +14,6 @@ template $BzUserDataPage: Adw.NavigationPage {
 
       Adw.ViewStackPage {
         name: "loading";
-        title: _("Loading");
 
         child: Adw.Spinner {
           halign: fill;
@@ -27,7 +26,6 @@ template $BzUserDataPage: Adw.NavigationPage {
 
       Adw.ViewStackPage {
         name: "empty";
-        title: _("Empty");
 
         child: Adw.StatusPage {
           icon-name: "folder-documents-symbolic";
@@ -37,7 +35,6 @@ template $BzUserDataPage: Adw.NavigationPage {
 
       Adw.ViewStackPage {
         name: "content";
-        title: _("User Data");
 
         child: ScrolledWindow {
           hscrollbar-policy: never;

--- a/src/context-tile-callbacks.c
+++ b/src/context-tile-callbacks.c
@@ -129,6 +129,7 @@ get_size_label (gpointer object,
   if (is_installable && !runtime_installed && runtime_size > 0)
     {
       g_autofree char *size_str = g_format_size (runtime_size);
+      // TRANSLATORS: %s is a formatted file size, for example: "128 MB"
       return g_strdup_printf (_ ("+%s runtime"), size_str);
     }
 
@@ -397,14 +398,19 @@ get_safety_rating_label (gpointer object,
   switch (importance)
     {
     case BZ_IMPORTANCE_UNIMPORTANT:
+      // TRANSLATORS: short app safety rating label
       return g_strdup (_ ("Safe"));
     case BZ_IMPORTANCE_NEUTRAL:
+      // TRANSLATORS: short app safety rating label
       return g_strdup (_ ("Low Risk"));
     case BZ_IMPORTANCE_INFORMATION:
+      // TRANSLATORS: short app safety rating label
       return g_strdup (_ ("Low Risk"));
     case BZ_IMPORTANCE_WARNING:
+      // TRANSLATORS: short app safety rating label
       return g_strdup (_ ("Medium Risk"));
     case BZ_IMPORTANCE_IMPORTANT:
+      // TRANSLATORS: short app safety rating label
       return g_strdup (_ ("High Risk"));
     default:
       return g_strdup (_ ("N/A"));


### PR DESCRIPTION
Most tiles in Adw.ViewStack never get shown to the user, as they only get used when using a view switcher, so it makes sense to remove them to spare the translators some work.