### PR TITLE
User Data Fixes

### DIFF
--- a/src/bz-user-data-page.blp
+++ b/src/bz-user-data-page.blp
@@ -28,8 +28,9 @@ template $BzUserDataPage: Adw.NavigationPage {
         name: "empty";
 
         child: Adw.StatusPage {
-          icon-name: "folder-documents-symbolic";
-          title: _("No User Data Found");
+          icon-name: "user-trash-symbolic";
+          title: _("No Leftover User Data Found");
+          description: _("Personal data left behind by apps that were removed will show up here");
         };
       }
 

--- a/src/bz-user-data-page.c
+++ b/src/bz-user-data-page.c
@@ -23,10 +23,11 @@
 #include <glib/gi18n.h>
 
 #include "bz-application-map-factory.h"
-#include "env.h"
-#include "io.h"
 #include "bz-user-data-page.h"
 #include "bz-user-data-tile.h"
+#include "bz-window.h"
+#include "env.h"
+#include "io.h"
 #include "util.h"
 
 struct _BzUserDataPage
@@ -35,6 +36,9 @@ struct _BzUserDataPage
 
   BzStateInfo *state;
   GListModel  *model;
+
+  AdwToast *toast;
+  guint     toast_count;
 
   /* Template widgets */
   AdwViewStack *stack;
@@ -62,6 +66,10 @@ items_changed (BzUserDataPage *self,
                guint           removed,
                guint           added,
                GListModel     *model);
+
+static void
+toast_dismissed_cb (BzUserDataPage *self,
+                    AdwToast       *toast);
 
 static void
 set_page (BzUserDataPage *self);
@@ -190,6 +198,52 @@ bz_user_data_page_new (BzStateInfo *state)
                        NULL);
 }
 
+void
+bz_user_data_page_remove_group (BzUserDataPage *self,
+                                BzEntryGroup   *group)
+{
+  guint            n_items, i;
+  const char      *title   = NULL;
+  g_autofree char *message = NULL;
+
+  if (self->model == NULL)
+    return;
+
+  title = bz_entry_group_get_title (group);
+
+  n_items = g_list_model_get_n_items (self->model);
+  for (i = 0; i < n_items; i++)
+    {
+      g_autoptr (BzEntryGroup) item = g_list_model_get_item (self->model, i);
+
+      if (item == group)
+        {
+          g_list_store_remove (G_LIST_STORE (self->model), i);
+          break;
+        }
+    }
+
+  self->toast_count++;
+
+  message = self->toast_count > 1
+                ? g_strdup_printf (_ ("Trashed User Data for %u Apps"), self->toast_count)
+                : g_strdup_printf (_ ("Trashed User Data for %s"), title);
+
+  if (self->toast == NULL)
+    {
+      self->toast = adw_toast_new (message);
+      g_object_add_weak_pointer (G_OBJECT (self->toast), (gpointer *) &self->toast);
+      g_signal_connect_swapped (self->toast, "dismissed",
+                                G_CALLBACK (toast_dismissed_cb), self);
+
+      bz_window_add_toast (
+          BZ_WINDOW (gtk_widget_get_root (GTK_WIDGET (self))),
+          self->toast);
+    }
+  else
+    adw_toast_set_title (self->toast, message);
+}
+
 static void
 items_changed (BzUserDataPage *self,
                guint           position,
@@ -198,6 +252,13 @@ items_changed (BzUserDataPage *self,
                GListModel     *model)
 {
   set_page (self);
+}
+
+static void
+toast_dismissed_cb (BzUserDataPage *self,
+                    AdwToast       *toast)
+{
+  self->toast_count = 0;
 }
 
 static void
@@ -231,8 +292,8 @@ fetch_user_data_fiber (GWeakRef *wr)
   g_autoptr (GListStore) sorted_store  = NULL;
   GListModel *installed_groups         = NULL;
   g_autoptr (GHashTable) installed_ids = NULL;
-  const char *own_id                  = NULL;
-  guint n_items                        = 0;
+  const char *own_id                   = NULL;
+  guint       n_items                  = 0;
 
   self = g_weak_ref_get (wr);
   if (self == NULL)

--- a/src/bz-user-data-page.h
+++ b/src/bz-user-data-page.h
@@ -31,4 +31,8 @@ G_DECLARE_FINAL_TYPE (BzUserDataPage, bz_user_data_page, BZ, USER_DATA_PAGE, Adw
 GtkWidget *
 bz_user_data_page_new (BzStateInfo *state);
 
+void
+bz_user_data_page_remove_group (BzUserDataPage *self,
+                                BzEntryGroup    *group);
+
 G_END_DECLS

--- a/src/bz-user-data-tile.blp
+++ b/src/bz-user-data-tile.blp
@@ -2,9 +2,9 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzUserDataTile: Adw.Bin {
-  child: Revealer {
+  child: Revealer revealer {
     transition-type: slide_down;
-    reveal-child: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.user-data-size) as <bool>) as <bool>;
+    reveal-child: true;
 
     child: Adw.Bin {
       accessibility {
@@ -12,10 +12,10 @@ template $BzUserDataTile: Adw.Bin {
         described-by: description_label;
       }
 
-      margin-bottom: 4;
+      margin-bottom: 5;
       margin-start: 4;
       margin-end: 4;
-      margin-top: 4;
+      margin-top: 5;
 
       styles [
         "card",
@@ -29,8 +29,8 @@ template $BzUserDataTile: Adw.Bin {
           margin-start: 10;
           margin-top: 10;
           margin-bottom: 10;
-          height-request: 48;
-          width-request: 48;
+          height-request: 64;
+          width-request: 64;
           paintable: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable;
           visible: bind try {$invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable) as <bool>) as <bool>, false};
 
@@ -43,9 +43,9 @@ template $BzUserDataTile: Adw.Bin {
           margin-start: 10;
           margin-top: 10;
           margin-bottom: 10;
-          height-request: 48;
-          width-request: 48;
-          pixel-size: 48;
+          height-request: 64;
+          width-request: 64;
+          pixel-size: 64;
           icon-name: "application-x-executable";
           visible: bind icon_picture.visible inverted;
 

--- a/src/bz-user-data-tile.c
+++ b/src/bz-user-data-tile.c
@@ -23,19 +23,20 @@
 #include <glib/gi18n.h>
 
 #include "bz-entry-group.h"
-#include "env.h"
-#include "error.h"
 #include "bz-state-info.h"
 #include "bz-user-data-page.h"
 #include "bz-user-data-tile.h"
+#include "env.h"
+#include "error.h"
 #include "util.h"
-#include "bz-window.h"
 
 struct _BzUserDataTile
 {
   BzListTile parent_instance;
 
   BzEntryGroup *group;
+
+  GtkRevealer *revealer;
 };
 
 G_DEFINE_FINAL_TYPE (BzUserDataTile, bz_user_data_tile, ADW_TYPE_BIN)
@@ -122,6 +123,24 @@ format_size (gpointer object, guint64 value)
   return g_format_size (value);
 }
 
+static void
+revealed_cb (GtkRevealer    *revealer,
+             GParamSpec     *pspec,
+             BzUserDataTile *self)
+{
+  BzUserDataPage *page;
+
+  if (gtk_revealer_get_child_revealed (revealer))
+    return;
+
+  page = BZ_USER_DATA_PAGE (
+      gtk_widget_get_ancestor (GTK_WIDGET (self), BZ_TYPE_USER_DATA_PAGE));
+  if (page != NULL)
+    bz_user_data_page_remove_group (page, self->group);
+
+  g_signal_handlers_disconnect_by_func (revealer, revealed_cb, self);
+}
+
 static DexFuture *
 reap_user_data_done (DexFuture *future,
                      GWeakRef  *wr)
@@ -142,13 +161,9 @@ reap_user_data_done (DexFuture *future,
         local_error->message);
   else
     {
-      g_autofree char *message = NULL;
-
-      message = g_strdup_printf (_ ("Trashed User Data for %s"),
-                                 bz_entry_group_get_title (self->group));
-      bz_window_add_toast (
-          BZ_WINDOW (gtk_widget_get_root (GTK_WIDGET (self))),
-          adw_toast_new (message));
+      g_signal_connect (self->revealer, "notify::child-revealed",
+                        G_CALLBACK (revealed_cb), self);
+      gtk_revealer_set_reveal_child (self->revealer, FALSE);
     }
 
   return dex_future_new_true ();
@@ -208,6 +223,8 @@ bz_user_data_tile_class_init (BzUserDataTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_size);
   gtk_widget_class_bind_template_callback (widget_class, folder_cb);
   gtk_widget_class_bind_template_callback (widget_class, remove_cb);
+
+  gtk_widget_class_bind_template_child (widget_class, BzUserDataTile, revealer);
 
   gtk_widget_class_set_accessible_role (widget_class, GTK_ACCESSIBLE_ROLE_BUTTON);
 }


### PR DESCRIPTION
Makes it so the empty page gets properly shown when the last entry gets removed.

Also makes it so only 1 toast can exist at a time, updating the count when every time the user removes an entry.

<img width="2376" height="1782" alt="Screenshot From 2026-07-28 22-02-49" src="https://github.com/user-attachments/assets/5d864885-c7bf-4ca2-a71a-9171f013edf9" />
<img width="2376" height="1782" alt="Screenshot From 2026-07-28 22-02-54" src="https://github.com/user-attachments/assets/163d0016-ddf7-4a7f-8999-5bd310ca1ef5" />
