### PR TITLE
Workaround cache invalidation issue for favorites

### DIFF
--- a/src/global-net.c
+++ b/src/global-net.c
@@ -163,7 +163,10 @@ bz_query_flathub_v2_json_authenticated (const char *request,
 
   dex_return_error_if_fail (request != NULL);
 
-  uri = g_strdup_printf ("https://flathub.org/api/v2%s", request);
+  uri = g_strdup_printf ("https://flathub.org/api/v2%s%c_=%" G_GINT64_FORMAT,
+                          request, strchr (request, '?') != NULL ? '&' : '?',
+                          g_get_real_time ());
+
   return query_uri_json_with_method (uri, SOUP_METHOD_GET, token);
 }
 


### PR DESCRIPTION
This should probably be fixed on Flathubs end, but this a fix that does technically work. https://github.com/flathub-infra/website/issues/6898
<img width="1200" height="598" alt="image" src="https://github.com/user-attachments/assets/2e8e7795-0561-4601-8d02-8f34ed16d90f" />