### PR TITLE
Have separate version for cache wipes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project('bazaar', 'c',
 # can't have statements before `project` ...
 bz_vcs_version = run_command('version.sh', 'get-vcs').stdout().strip()
 bz_version = run_command('version.sh', 'get-version').stdout().strip()
+bz_cache_version = run_command('version.sh', 'get-cache').stdout().strip()
 
 python3 = find_program('python3')
 i18n = import('i18n')
@@ -93,6 +94,7 @@ else
 
     config_h.set_quoted('PACKAGE_VERSION', bz_version)
     config_h.set_quoted('PACKAGE_VCS_VERSION', bz_vcs_version)
+    config_h.set_quoted('CACHE_VERSION', bz_cache_version)
     config_h.set_quoted('GETTEXT_PACKAGE', 'bazaar')
     config_h.set_quoted('APPLICATION_ID', 'io.github.kolunmi.Bazaar')
     config_h.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1075,7 +1075,7 @@ init_fiber (GWeakRef *wr)
                   const char *version = NULL;
 
                   version    = g_variant_get_string (variant, NULL);
-                  wipe_cache = g_strcmp0 (version, PACKAGE_VERSION) != 0;
+                  wipe_cache = g_strcmp0 (version, CACHE_VERSION) != 0;
                 }
             }
         }
@@ -1083,6 +1083,7 @@ init_fiber (GWeakRef *wr)
       if (wipe_cache)
         {
           bz_state_info_set_donation_prompt_dismissed (self->state, FALSE);
+          g_settings_set_int64 (self->settings, "last-refresh-time", 0);
 
           g_info ("Version incompatibility detected: clearing cache");
           dex_await (bz_reap_file_dex (root_cache_dir_file), NULL);
@@ -1100,7 +1101,7 @@ init_fiber (GWeakRef *wr)
         g_autoptr (GVariant) variant = NULL;
         g_autoptr (GBytes) bytes     = NULL;
 
-        variant = g_variant_new_string (PACKAGE_VERSION);
+        variant = g_variant_new_string (CACHE_VERSION);
         bytes   = g_variant_get_data_as_bytes (variant);
         dex_await (dex_file_replace_contents_bytes (
                        cache_version_file, bytes, NULL, FALSE,

--- a/version.sh
+++ b/version.sh
@@ -3,6 +3,7 @@
 INSTR="$1"
 
 VERSION=0.9.2
+CACHE_VERSION=1
 
 case "$INSTR" in
     get-version)
@@ -19,6 +20,9 @@ case "$INSTR" in
     get-gh-release)
         TAG="v${VERSION}"
         echo "https://github.com/bazaar-org/bazaar/releases/tag/${TAG}"
+        ;;
+    get-cache)
+        echo "${CACHE_VERSION}"
         ;;
     *)
         echo invalid arguments 1>&2


### PR DESCRIPTION
Makes it so we don't have to wipe the cache for smaller releases that don't touch any cached data.

It also allows us to reset the cache of other developers without having to do a version bump.

Also fixes an issue where the cache would be wiped, but not be refreshed if the user already refreshed the cache in the last day.

Closes #1755