### PR TITLE
Fix focus for safety dialog

### DIFF
--- a/src/bz-safety-dialog.blp
+++ b/src/bz-safety-dialog.blp
@@ -18,6 +18,7 @@ template $BzSafetyDialog: Adw.Bin {
       ScrolledWindow {
         hscrollbar-policy: never;
         hexpand: true;
+        sensitive: bind $is_page(carousel.position, 0) as <bool>;
 
         Box global_box {
           orientation: vertical;
@@ -45,10 +46,11 @@ template $BzSafetyDialog: Adw.Bin {
             margin-bottom: 18;
             margin-start: 18;
             margin-end: 18;
-            label: _("This app has a permission that indirectly allows it to grant itself <b>any other permission it wants</b>, bypassing the Flatpak sandbox.\n\nIt can therefore do anything a normal, non-sandboxed application can do, such as accessing all your files and connecting to the internet.\n\nViewing the other permissions may still give a better idea of what the app is likely to do.");
+            selectable: true;
+            label: _("This app has a permission that indirectly allows it to grant itself <b>any other permission it wants</b>, bypassing the Flatpak sandbox.\n\nIt can therefore do anything a privileged, non-sandboxed application can do, such as accessing all your files and connecting to the internet.\n\nViewing the other permissions may still give a better idea of what the app is likely to do.");
           }
 
-          Button {
+          Button other_permissions_button {
             label: _("View Other Permissions");
             clicked => $next_page(template);
             margin-bottom: 12;
@@ -62,6 +64,7 @@ template $BzSafetyDialog: Adw.Bin {
       ScrolledWindow {
         hscrollbar-policy: never;
         hexpand: true;
+        sensitive: bind $is_page(carousel.position, 1) as <bool>;
 
         Adw.Clamp {
           maximum-size: 640;

--- a/src/bz-safety-dialog.c
+++ b/src/bz-safety-dialog.c
@@ -48,6 +48,7 @@ struct _BzSafetyDialog
   GtkListBox  *permissions_list;
   AdwCarousel *carousel;
   GtkBox      *global_box;
+  GtkButton   *other_permissions_button;
 };
 
 G_DEFINE_FINAL_TYPE (BzSafetyDialog, bz_safety_dialog, ADW_TYPE_BIN)
@@ -193,6 +194,8 @@ on_dialog_map (BzSafetyDialog *self)
       page = gtk_widget_get_last_child (GTK_WIDGET (self->carousel));
       adw_carousel_scroll_to (self->carousel, page, FALSE);
     }
+  else
+    gtk_widget_grab_focus (GTK_WIDGET (self->other_permissions_button));
 
   get_target_size (self, page_index, &target_width, &target_height);
   adw_dialog_set_content_width (dialog, target_width);
@@ -208,6 +211,15 @@ next_page (BzSafetyDialog *self,
   page = gtk_widget_get_last_child (GTK_WIDGET (self->carousel));
   adw_carousel_scroll_to (self->carousel, page, TRUE);
   animate_to_page (self, 1);
+}
+
+static gboolean
+is_page (gpointer object,
+         gdouble  position,
+         gint     target)
+{
+  return fabs (position - (gdouble) target) < 0.5 ||
+        fabs (position - round (position)) > 0.01;
 }
 
 static void
@@ -241,7 +253,9 @@ bz_safety_dialog_class_init (BzSafetyDialogClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, permissions_list);
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, carousel);
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, global_box);
+  gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, other_permissions_button);
   gtk_widget_class_bind_template_callback (widget_class, next_page);
+  gtk_widget_class_bind_template_callback (widget_class, is_page);
 }
 
 static void


### PR DESCRIPTION
makes the arbitrary permissions label selectable and makes it so only content on the current page is selectable.