### PR TITLE
Make read only apps appear in the installed apps list when loaded from groups cache

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1350,9 +1350,10 @@ enumerate_disk_groups_fiber (GWeakRef *wr)
       group = bz_entry_group_new (self->entry_factory);
       if (bz_entry_group_deserialize (group, group_variant))
         {
-          const char *id = NULL;
+          const char *id           = NULL;
+          gboolean    is_installed = FALSE;
 
-          bz_entry_group_reconcile_with_installed_set (group, self->installed_set);
+          is_installed = bz_entry_group_reconcile_with_installed_set (group, self->installed_set);
 
           if (!has_flathub_group &&
               bz_entry_group_get_is_flathub (group))
@@ -1367,7 +1368,7 @@ enumerate_disk_groups_fiber (GWeakRef *wr)
                 g_strdup (id),
                 g_object_ref (group));
 
-          if (bz_entry_group_get_removable (group) > 0)
+          if (is_installed)
             g_list_store_insert_sorted (
                 self->installed_apps, group,
                 (GCompareDataFunc) cmp_group, NULL);

--- a/src/bz-entry-group.c
+++ b/src/bz-entry-group.c
@@ -1872,15 +1872,16 @@ bz_entry_group_deserialize (BzEntryGroup *self,
   return self->id != NULL;
 }
 
-void
+gboolean
 bz_entry_group_reconcile_with_installed_set (BzEntryGroup *self,
                                              GHashTable   *installed_set)
 {
   g_autoptr (GMutexLocker) locker = NULL;
   guint n_ids                     = 0;
+  gboolean any_installed          = FALSE;
 
-  g_return_if_fail (BZ_IS_ENTRY_GROUP (self));
-  g_return_if_fail (installed_set != NULL);
+  g_return_val_if_fail (BZ_IS_ENTRY_GROUP (self), FALSE);
+  g_return_val_if_fail (installed_set != NULL, FALSE);
 
   locker = g_mutex_locker_new (&self->mutex);
 
@@ -1904,6 +1905,7 @@ bz_entry_group_reconcile_with_installed_set (BzEntryGroup *self,
           flags |= ENTRY_REMOVABLE | ENTRY_REMOVABLE_AVAILABLE;
           self->removable++;
           self->removable_available++;
+          any_installed = TRUE;
         }
       else
         {
@@ -1919,4 +1921,6 @@ bz_entry_group_reconcile_with_installed_set (BzEntryGroup *self,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_REMOVABLE_AND_AVAILABLE]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE_AND_AVAILABLE]);
+
+  return any_installed;
 }

--- a/src/bz-entry-group.h
+++ b/src/bz-entry-group.h
@@ -179,7 +179,7 @@ gboolean
 bz_entry_group_deserialize (BzEntryGroup *self,
                             GVariant     *import);
 
-void
+gboolean
 bz_entry_group_reconcile_with_installed_set (BzEntryGroup *self,
                                              GHashTable   *installed_set);
 


### PR DESCRIPTION
This fixes an issue where the Bazaar app would not appear in the list until after a refresh happened.