### PR TITLE
Clarify affected ubuntu versions in warning dialog

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1027,7 +1027,7 @@ init_fiber (GWeakRef *wr)
           adw_alert_dialog_format_heading (ADW_ALERT_DIALOG (alert), _ ("Ubuntu Troubles!"));
           adw_alert_dialog_format_body_markup (
               ADW_ALERT_DIALOG (alert),
-              _ ("The more recent versions of Ubuntu have messed up default security rules, "
+              _ ("Ubuntu 25.10 and newer have messed up default security rules, "
                  "making it <b>impossible to install apps</b> from the Flatpak version "
                  "of Bazaar, please just use the normal package for now by using\n\n"
                  "<tt>sudo apt install bazaar</tt>\n\n"


### PR DESCRIPTION
Ubuntu 24.04 is still being supported and used. It does not suffer from https://github.com/bazaar-org/bazaar/issues/583.

I think it is still worth showing the warning to unaffected 24.04 users because in the future Bazaar will stop working as soon as they upgrade their system.

Fixes: https://github.com/bazaar-org/bazaar/issues/1708
<img width="1068" height="963" alt="Screenshot_20260805_013935" src="https://github.com/user-attachments/assets/f140e20d-63c5-42ff-a481-8ec724949f0b" />

