### PR TITLE
Handle background transactions better

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -150,4 +150,5 @@ src/io.c
 src/main.c
 src/safety-calculator.c
 src/shortcuts-dialog.blp
+src/transaction-notification.c
 src/update-worker.c

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -312,6 +312,11 @@ disable_blocklists_changed (BzApplication *self,
                             BzStateInfo   *state);
 
 static void
+transactions_active_changed (BzApplication        *self,
+                             GParamSpec           *pspec,
+                             BzTransactionManager *transactions);
+
+static void
 show_hide_app_setting_changed (BzApplication *self,
                                const char    *key,
                                GSettings     *settings);
@@ -2882,6 +2887,18 @@ disable_blocklists_changed (BzApplication *self,
   gtk_filter_changed (GTK_FILTER (self->appid_filter), GTK_FILTER_CHANGE_DIFFERENT);
 }
 
+
+static void
+transactions_active_changed (BzApplication        *self,
+                              GParamSpec           *pspec,
+                              BzTransactionManager *transactions)
+{
+  if (bz_transaction_manager_get_active (transactions))
+    g_application_hold (G_APPLICATION (self));
+  else
+    g_application_release (G_APPLICATION (self));
+}
+
 static void
 show_hide_app_setting_changed (BzApplication *self,
                                const char    *key,
@@ -3605,6 +3622,11 @@ init_service_struct (BzApplication *self,
 
   self->transactions = bz_transaction_manager_new ();
   bz_transaction_manager_set_config (self->transactions, self->config);
+
+  g_signal_connect_swapped (
+    self->transactions, "notify::active",
+    G_CALLBACK (transactions_active_changed),
+    self);
 
   bz_state_info_set_all_entry_groups (self->state, G_LIST_MODEL (self->groups));
   bz_state_info_set_all_installed_entry_groups (self->state, G_LIST_MODEL (self->installed_apps));

--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -536,24 +536,32 @@ bz_async_texture_dup_future (BzAsyncTexture *self)
         "texture is in an invalid state");
 }
 
-GIcon *
-bz_async_texture_dup_icon (BzAsyncTexture *self)
+static DexFuture *
+icon_from_bytes_then (DexFuture *future,
+                      gpointer   user_data)
 {
-  g_autoptr (GError) local_error = NULL;
-  g_autoptr (GBytes) bytes       = NULL;
-  GFile *file                    = NULL;
+  g_autoptr (GIcon) icon = NULL;
+
+  icon = g_bytes_icon_new (g_value_get_boxed (dex_future_get_value (future, NULL)));
+  return dex_future_new_for_object (icon);
+}
+
+DexFuture *
+bz_async_texture_dup_icon_future (BzAsyncTexture *self)
+{
+  GFile *file = NULL;
 
   g_return_val_if_fail (BZ_IS_ASYNC_TEXTURE (self), NULL);
 
   file = self->cache_into != NULL ? self->cache_into : self->source;
   if (file == NULL)
-    return NULL;
+    return dex_future_new_reject (
+        G_IO_ERROR, G_IO_ERROR_FAILED, "no source file to load icon from");
 
-  bytes = g_file_load_bytes (file, NULL, NULL, &local_error);
-  if (bytes == NULL)
-    return NULL;
-
-  return g_bytes_icon_new (bytes);
+  return dex_future_then (
+      dex_file_load_contents_bytes (file),
+      icon_from_bytes_then,
+      NULL, NULL);
 }
 
 void

--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -536,6 +536,26 @@ bz_async_texture_dup_future (BzAsyncTexture *self)
         "texture is in an invalid state");
 }
 
+GIcon *
+bz_async_texture_dup_icon (BzAsyncTexture *self)
+{
+  g_autoptr (GError) local_error = NULL;
+  g_autoptr (GBytes) bytes       = NULL;
+  GFile *file                    = NULL;
+
+  g_return_val_if_fail (BZ_IS_ASYNC_TEXTURE (self), NULL);
+
+  file = self->cache_into != NULL ? self->cache_into : self->source;
+  if (file == NULL)
+    return NULL;
+
+  bytes = g_file_load_bytes (file, NULL, NULL, &local_error);
+  if (bytes == NULL)
+    return NULL;
+
+  return g_bytes_icon_new (bytes);
+}
+
 void
 bz_async_texture_ensure (BzAsyncTexture *self)
 {

--- a/src/bz-async-texture.h
+++ b/src/bz-async-texture.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
+#include <gio/gio.h>
 #include <libdex.h>
 
 G_BEGIN_DECLS
@@ -71,6 +72,9 @@ bz_async_texture_get_loaded (BzAsyncTexture *self);
 
 GdkTexture *
 bz_async_texture_dup_texture (BzAsyncTexture *self);
+
+GIcon *
+bz_async_texture_dup_icon (BzAsyncTexture *self);
 
 DexFuture *
 bz_async_texture_dup_future (BzAsyncTexture *self);

--- a/src/bz-async-texture.h
+++ b/src/bz-async-texture.h
@@ -73,11 +73,11 @@ bz_async_texture_get_loaded (BzAsyncTexture *self);
 GdkTexture *
 bz_async_texture_dup_texture (BzAsyncTexture *self);
 
-GIcon *
-bz_async_texture_dup_icon (BzAsyncTexture *self);
-
 DexFuture *
 bz_async_texture_dup_future (BzAsyncTexture *self);
+
+DexFuture *
+bz_async_texture_dup_icon_future (BzAsyncTexture *self);
 
 void
 bz_async_texture_ensure (BzAsyncTexture *self);

--- a/src/bz-transaction-manager.c
+++ b/src/bz-transaction-manager.c
@@ -26,9 +26,10 @@
 
 #include "bz-backend-transaction-op-payload.h"
 #include "bz-backend-transaction-op-progress-payload.h"
-#include "env.h"
 #include "bz-marshalers.h"
 #include "bz-transaction-manager.h"
+#include "env.h"
+#include "transaction-notification.h"
 #include "util.h"
 
 /* clang-format off */
@@ -807,6 +808,8 @@ transaction_finally (DexFuture          *future,
 
   self->current_progress = 1.0;
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CURRENT_PROGRESS]);
+
+  bz_transaction_notify_finished(transaction, value != NULL);
 
   if (value != NULL)
     {

--- a/src/meson.build
+++ b/src/meson.build
@@ -174,6 +174,7 @@ bz_sources = files(
   'search-index-write.c',
   'spdx.c',
   'template-callbacks.c',
+  'transaction-notification.c',
   'update-worker.c',
 )
 subdir('progress-bar-designs')

--- a/src/transaction-notification.c
+++ b/src/transaction-notification.c
@@ -26,26 +26,78 @@
 #include "bz-async-texture.h"
 #include "bz-entry.h"
 #include "bz-transaction-entry-tracker.h"
+#include "env.h"
 #include "transaction-notification.h"
+#include "util.h"
+
+BZ_DEFINE_DATA (
+    notify_finished,
+    NotifyFinished,
+    {
+      BzTransaction *transaction;
+      gboolean       success;
+    },
+    BZ_RELEASE_DATA (transaction, g_object_unref))
+
+static DexFuture *
+notify_finished_release_hold (DexFuture    *future,
+                              GApplication *app);
+
+static DexFuture *
+notify_finished_fiber (NotifyFinishedData *data);
 
 void
 bz_transaction_notify_finished (BzTransaction *transaction,
                                 gboolean       success)
 {
-  GApplication *app        = NULL;
-  GList        *windows    = NULL;
-  GListModel   *trackers   = NULL;
-  guint         n_trackers = 0;
+  g_autoptr (NotifyFinishedData) data = NULL;
+  GApplication *app                   = NULL;
 
   g_return_if_fail (BZ_IS_TRANSACTION (transaction));
 
-  app     = g_application_get_default ();
+  app = g_application_get_default ();
+  g_application_hold (app);
+
+  data              = notify_finished_data_new ();
+  data->transaction = g_object_ref (transaction);
+  data->success     = success;
+
+  dex_future_disown (dex_future_finally (
+      dex_scheduler_spawn (
+          dex_scheduler_get_default (),
+          bz_get_dex_stack_size (),
+          (DexFiberFunc) notify_finished_fiber,
+          notify_finished_data_ref (data),
+          notify_finished_data_unref),
+      (DexFutureCallback) notify_finished_release_hold,
+      app, NULL));
+}
+
+static DexFuture *
+notify_finished_release_hold (DexFuture    *future,
+                              GApplication *app)
+{
+  g_application_release (app);
+  return dex_ref (future);
+}
+
+static DexFuture *
+notify_finished_fiber (NotifyFinishedData *data)
+{
+  BzTransaction *transaction = data->transaction;
+  GApplication  *app         = NULL;
+  GList         *windows     = NULL;
+  GListModel    *trackers    = NULL;
+  guint          n_trackers  = 0;
+
+  if (!data->success)
+    return dex_future_new_true ();
+
+  app = g_application_get_default ();
+
   windows = gtk_application_get_windows (GTK_APPLICATION (app));
   if (windows != NULL)
-    return;
-
-  if (!success)
-    return;
+    return dex_future_new_true ();
 
   trackers = bz_transaction_get_trackers (transaction);
   if (trackers != NULL)
@@ -94,4 +146,6 @@ bz_transaction_notify_finished (BzTransaction *transaction,
       notif_id = g_strdup_printf ("app-installed-%s", bz_entry_get_unique_id (entry));
       g_application_send_notification (app, notif_id, notification);
     }
+
+  return dex_future_new_true ();
 }

--- a/src/transaction-notification.c
+++ b/src/transaction-notification.c
@@ -136,7 +136,9 @@ notify_finished_fiber (NotifyFinishedData *data)
 
       paintable = bz_entry_get_icon_paintable (entry);
       if (paintable != NULL && BZ_IS_ASYNC_TEXTURE (paintable))
-        icon = bz_async_texture_dup_icon (BZ_ASYNC_TEXTURE (paintable));
+        icon = (GIcon *) dex_await_object (
+            bz_async_texture_dup_icon_future (BZ_ASYNC_TEXTURE (paintable)),
+            NULL);
 
       if (icon != NULL)
         g_notification_set_icon (notification, icon);

--- a/src/transaction-notification.c
+++ b/src/transaction-notification.c
@@ -1,0 +1,97 @@
+/* transaction-notification.c
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+
+#include "bz-async-texture.h"
+#include "bz-entry.h"
+#include "bz-transaction-entry-tracker.h"
+#include "transaction-notification.h"
+
+void
+bz_transaction_notify_finished (BzTransaction *transaction,
+                                gboolean       success)
+{
+  GApplication *app        = NULL;
+  GList        *windows    = NULL;
+  GListModel   *trackers   = NULL;
+  guint         n_trackers = 0;
+
+  g_return_if_fail (BZ_IS_TRANSACTION (transaction));
+
+  app     = g_application_get_default ();
+  windows = gtk_application_get_windows (GTK_APPLICATION (app));
+  if (windows != NULL)
+    return;
+
+  if (!success)
+    return;
+
+  trackers = bz_transaction_get_trackers (transaction);
+  if (trackers != NULL)
+    n_trackers = g_list_model_get_n_items (trackers);
+
+  for (guint i = 0; i < n_trackers; i++)
+    {
+      g_autoptr (BzTransactionEntryTracker) tracker = NULL;
+      BzTransactionEntryKind kind                   = 0;
+      BzEntry               *entry                  = NULL;
+      const char            *title                  = NULL;
+      g_autofree char       *summary                = NULL;
+      g_autofree char       *notif_id               = NULL;
+      g_autoptr (GNotification) notification        = NULL;
+      g_autoptr (GIcon) icon                        = NULL;
+      GdkPaintable *paintable                       = NULL;
+
+      tracker = g_list_model_get_item (trackers, i);
+      kind    = bz_transaction_entry_tracker_get_kind (tracker);
+      if (kind != BZ_TRANSACTION_ENTRY_KIND_INSTALL)
+        continue;
+
+      entry = bz_transaction_entry_tracker_get_entry (tracker);
+      if (entry == NULL || !bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_APPLICATION))
+        continue;
+
+      title = bz_entry_get_title (entry);
+      if (title == NULL)
+        title = bz_entry_get_id (entry);
+      if (title == NULL)
+        continue;
+
+      summary      = g_strdup_printf (_ ("%s Installed"), title);
+      notification = g_notification_new (summary);
+      g_notification_set_body (notification, _ ("The app is ready to be used"));
+
+      paintable = bz_entry_get_icon_paintable (entry);
+      if (paintable != NULL && BZ_IS_ASYNC_TEXTURE (paintable))
+        icon = bz_async_texture_dup_icon (BZ_ASYNC_TEXTURE (paintable));
+
+      if (icon != NULL)
+        g_notification_set_icon (notification, icon);
+
+      g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_NORMAL);
+
+      notif_id = g_strdup_printf ("app-installed-%s", bz_entry_get_unique_id (entry));
+      g_application_send_notification (app, notif_id, notification);
+    }
+}

--- a/src/transaction-notification.h
+++ b/src/transaction-notification.h
@@ -1,0 +1,33 @@
+/* transaction-notification.h
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#include "bz-transaction.h"
+
+G_BEGIN_DECLS
+
+void
+bz_transaction_notify_finished (BzTransaction *transaction,
+                                gboolean       success);
+
+G_END_DECLS


### PR DESCRIPTION
Keeps the main application running until all transactions are complete, and sends a notification if all windows are closed when an application finishes installing, making sure the user stays informed.

<img width="1194" height="366" alt="image" src="https://github.com/user-attachments/assets/9ff04bf6-f6d1-466e-943b-2ea89ab1d9df" />

Closes #1793 