### PR TITLE
chore: pin flit_core to 3.X

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -181,7 +181,10 @@
                                     "sha256": "18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2",
                                     "x-checker-data": {
                                         "type": "pypi",
-                                        "name": "flit_core"
+                                        "name": "flit_core",
+                                        "versions": {
+                                          "<": "4"
+                                        }
                                     }
                                 }
                             ]


### PR DESCRIPTION
Follow-up of b74b4ff.

Pyparsing can't currently be built with 4.X.

https://github.com/pyparsing/pyparsing/blob/86fac1d6313de4cd8558179e8599c9eb53c272ca/pyproject.toml#L2