### PR TITLE
Make dialogs more accessible

### DIFF
--- a/src/bz-addons-dialog.blp
+++ b/src/bz-addons-dialog.blp
@@ -4,6 +4,7 @@ using Adw 1;
 template $BzAddonsDialog: Adw.Dialog {
   content-width: 500;
   content-height: 550;
+  title: _("Add-on");
 
   child: Adw.ToastOverlay {
     child:Adw.NavigationView navigation_view {

--- a/src/bz-age-rating-dialog.c
+++ b/src/bz-age-rating-dialog.c
@@ -695,6 +695,7 @@ update_lozenge (BzAgeRatingDialog *self,
   guint                 age        = G_MAXUINT;
   g_autofree gchar     *age_text   = NULL;
   g_autofree gchar     *title_text = NULL;
+  g_autofree gchar     *a11y_desc  = NULL;
   BzImportance          importance = BZ_IMPORTANCE_NEUTRAL;
   gboolean              is_unknown = FALSE;
 
@@ -774,6 +775,11 @@ update_lozenge (BzAgeRatingDialog *self,
   bz_lozenge_set_label (self->lozenge, age_text);
   bz_lozenge_set_title (self->lozenge, title_text);
   bz_lozenge_set_importance (self->lozenge, importance);
+
+  a11y_desc = g_strdup_printf ("%s. %s", age_text, title_text);
+  gtk_accessible_update_property (GTK_ACCESSIBLE (self),
+                                  GTK_ACCESSIBLE_PROPERTY_DESCRIPTION, a11y_desc,
+                                  -1);
 }
 
 static void

--- a/src/bz-app-size-dialog.c
+++ b/src/bz-app-size-dialog.c
@@ -192,6 +192,7 @@ bz_app_size_dialog_new (BzEntryGroup *group)
 
   dialog = adw_dialog_new ();
   adw_dialog_set_content_width (dialog, 600);
+  adw_dialog_set_title (dialog, _("Storage"));
   adw_dialog_set_child (dialog, GTK_WIDGET (widget));
 
   return dialog;
@@ -204,7 +205,7 @@ bz_app_size_page_new (BzEntryGroup *group)
   AdwNavigationPage *page   = NULL;
 
   widget = g_object_new (BZ_TYPE_APP_SIZE_DIALOG, "group", group, NULL);
-  page   = adw_navigation_page_new (GTK_WIDGET (widget), _ ("App Size"));
+  page   = adw_navigation_page_new (GTK_WIDGET (widget), _ ("Storage"));
   adw_navigation_page_set_tag (page, "app-size");
 
   return page;

--- a/src/bz-hardware-support-dialog.c
+++ b/src/bz-hardware-support-dialog.c
@@ -214,6 +214,10 @@ update_header (BzHardwareSupportDialog *self)
   bz_lozenge_set_icon_names (self->lozenge, icon_names);
   bz_lozenge_set_title (self->lozenge, title_text);
   bz_lozenge_set_importance (self->lozenge, importance);
+
+  gtk_accessible_update_property (GTK_ACCESSIBLE (self),
+                                  GTK_ACCESSIBLE_PROPERTY_DESCRIPTION, title_text,
+                                  -1);
 }
 
 static void

--- a/src/bz-license-dialog.c
+++ b/src/bz-license-dialog.c
@@ -334,14 +334,21 @@ bz_license_dialog_init (BzLicenseDialog *self)
 AdwDialog *
 bz_license_dialog_new (BzEntry *entry)
 {
-  BzLicenseDialog *widget = NULL;
-  AdwDialog       *dialog = NULL;
+  BzLicenseDialog *widget      = NULL;
+  AdwDialog       *dialog      = NULL;
+  g_autofree char *description = NULL;
 
   widget = g_object_new (BZ_TYPE_LICENSE_DIALOG, "entry", entry, NULL);
 
   dialog = adw_dialog_new ();
   adw_dialog_set_content_width (dialog, 425);
+  adw_dialog_set_title (dialog, _ ("License"));
   adw_dialog_set_child (dialog, GTK_WIDGET (widget));
+
+  description = get_label_cb (NULL, entry);
+  gtk_accessible_update_property (GTK_ACCESSIBLE (dialog),
+                                   GTK_ACCESSIBLE_PROPERTY_DESCRIPTION, description,
+                                   -1);
 
   return dialog;
 }
@@ -349,12 +356,18 @@ bz_license_dialog_new (BzEntry *entry)
 AdwNavigationPage *
 bz_license_page_new (BzEntry *entry)
 {
-  BzLicenseDialog   *widget = NULL;
-  AdwNavigationPage *page   = NULL;
+  BzLicenseDialog   *widget      = NULL;
+  AdwNavigationPage *page        = NULL;
+  g_autofree char   *description = NULL;
 
   widget = g_object_new (BZ_TYPE_LICENSE_DIALOG, "entry", entry, NULL);
   page   = adw_navigation_page_new (GTK_WIDGET (widget), _ ("License"));
   adw_navigation_page_set_tag (page, "license");
+
+  description = get_label_cb (NULL, entry);
+  gtk_accessible_update_property (GTK_ACCESSIBLE (page),
+                                  GTK_ACCESSIBLE_PROPERTY_DESCRIPTION, description,
+                                  -1);
 
   return page;
 }

--- a/src/bz-safety-dialog.blp
+++ b/src/bz-safety-dialog.blp
@@ -39,14 +39,13 @@ template $BzSafetyDialog: Adw.Bin {
             margin-bottom: 8;
           }
 
-          Label {
+          Label arbitrary_description {
             wrap: true;
             xalign: 0;
             use-markup: true;
             margin-bottom: 18;
             margin-start: 18;
             margin-end: 18;
-            selectable: true;
             label: _("This app has a permission that indirectly allows it to grant itself <b>any other permission it wants</b>, bypassing the Flatpak sandbox.\n\nIt can therefore do anything a privileged, non-sandboxed application can do, such as accessing all your files and connecting to the internet.\n\nViewing the other permissions may still give a better idea of what the app is likely to do.");
           }
 

--- a/src/bz-safety-dialog.c
+++ b/src/bz-safety-dialog.c
@@ -48,7 +48,7 @@ struct _BzSafetyDialog
   GtkListBox  *permissions_list;
   AdwCarousel *carousel;
   GtkBox      *global_box;
-  GtkButton   *other_permissions_button;
+  GtkLabel    *arbitrary_description;
 };
 
 G_DEFINE_FINAL_TYPE (BzSafetyDialog, bz_safety_dialog, ADW_TYPE_BIN)
@@ -194,8 +194,6 @@ on_dialog_map (BzSafetyDialog *self)
       page = gtk_widget_get_last_child (GTK_WIDGET (self->carousel));
       adw_carousel_scroll_to (self->carousel, page, FALSE);
     }
-  else
-    gtk_widget_grab_focus (GTK_WIDGET (self->other_permissions_button));
 
   get_target_size (self, page_index, &target_width, &target_height);
   adw_dialog_set_content_width (dialog, target_width);
@@ -209,6 +207,11 @@ next_page (BzSafetyDialog *self,
   GtkWidget *page = NULL;
 
   page = gtk_widget_get_last_child (GTK_WIDGET (self->carousel));
+
+  gtk_accessible_announce (GTK_ACCESSIBLE (self),
+                         bz_lozenge_get_title (self->lozenge),
+                         GTK_ACCESSIBLE_ANNOUNCEMENT_PRIORITY_MEDIUM);
+
   adw_carousel_scroll_to (self->carousel, page, TRUE);
   animate_to_page (self, 1);
 }
@@ -253,7 +256,7 @@ bz_safety_dialog_class_init (BzSafetyDialogClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, permissions_list);
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, carousel);
   gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, global_box);
-  gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, other_permissions_button);
+  gtk_widget_class_bind_template_child (widget_class, BzSafetyDialog, arbitrary_description);
   gtk_widget_class_bind_template_callback (widget_class, next_page);
   gtk_widget_class_bind_template_callback (widget_class, is_page);
 }
@@ -271,10 +274,13 @@ bz_safety_dialog_new (BzEntry *entry)
   AdwDialog          *dialog        = NULL;
   AdwAnimationTarget *width_target  = NULL;
   AdwAnimationTarget *height_target = NULL;
+  g_autofree char    *description   = NULL;
 
   widget = g_object_new (BZ_TYPE_SAFETY_DIALOG, NULL);
 
   dialog = adw_dialog_new ();
+
+  adw_dialog_set_title (dialog, _ ("Safety"));
   adw_dialog_set_content_height (dialog, 576);
   adw_dialog_set_content_width (dialog, 640);
   adw_dialog_set_child (dialog, GTK_WIDGET (widget));
@@ -286,8 +292,18 @@ bz_safety_dialog_new (BzEntry *entry)
 
   g_object_set (widget, "entry", entry, NULL);
 
-  g_signal_connect_swapped (widget, "map", G_CALLBACK (on_dialog_map), widget);
+  if (widget->has_sandbox_escape)
+    description = g_strdup_printf ("%s. %s",
+                                   _ ("Arbitrary Permissions"),
+                                   gtk_label_get_text (widget->arbitrary_description));
+  else
+    description = g_strdup (bz_lozenge_get_title (widget->lozenge));
 
+  gtk_accessible_update_property (GTK_ACCESSIBLE (dialog),
+                                  GTK_ACCESSIBLE_PROPERTY_DESCRIPTION, description,
+                                  -1);
+
+  g_signal_connect_swapped (widget, "map", G_CALLBACK (on_dialog_map), widget);
   return dialog;
 }
 


### PR DESCRIPTION
Makes the titles under the lozenges get read by screen readers in dialogs where it makes sense. Also ensures that all text on the arbitrary permissions page is read before the button.