### PR TITLE
Add Swedish translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -22,6 +22,7 @@ pt
 pt_BR
 ru
 sl
+sv
 tr
 uk
 vi

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,0 +1,3476 @@
+# Swedish translation for bazaar.
+# Copyright © 2026 bazaar's COPYRIGHT HOLDER
+# This file is distributed under the same license as the bazaar package.
+# Anders Jonsson <anders.jonsson@norsjovallen.se>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: bazaar main\n"
+"Report-Msgid-Bugs-To: https://github.com/bazaar-org/bazaar/issues\n"
+"POT-Creation-Date: 2026-08-10 09:14+0000\n"
+"PO-Revision-Date: 2026-08-10 14:28+0200\n"
+"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:2
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:7 src/bz-window.blp:47
+#: src/bz-window.blp:203 src/bz-window.c:387 src/bz-window.c:388
+msgid "Bazaar"
+msgstr "Bazaar"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:3
+msgid "App Store"
+msgstr "Programbutik"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:4
+msgid "Add, remove or update flatpak software on this computer"
+msgstr "Lägg till, ta bort eller uppdatera flatpak-programvara på denna dator"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:10
+msgid "System;Package;Manager;Discover;Flatpak;Software;App;Store;"
+msgstr "System;Paket;Hanterare;Upptäck;Flatpak;Programvara;App;Store;Butik;Affär;"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:17
+msgid "New Window"
+msgstr "Nytt fönster"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:8
+msgid "Discover and install apps"
+msgstr "Upptäck och installera program"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:10
+msgid ""
+"A fast and modern app store for Linux with a focus on discovering and "
+"installing Flatpak apps and add-ons, particularly from Flathub."
+msgstr ""
+"En snabb och modern programbutik för Linux med fokus på upptäckt och "
+"installation av Flatpak-program och tillägg, främst från Flathub."
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:15
+msgid "Queue multiple installs and keep browsing"
+msgstr "Köa flera installationer och fortsätt bläddra"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:16
+msgid "Easily view app permissions"
+msgstr "Se lätt programrättigheter"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:17
+msgid "Sign in to Flathub to view and manage your favorites"
+msgstr "Logga in med Flathub för att visa och hantera favoriter"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:18
+msgid "Search apps directly from GNOME Shell"
+msgstr "Sök program direkt från GNOME Shell"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:30 src/bz-application.c:771
+msgid "The Bazaar Contributors"
+msgstr "Bidragsgivarna till Bazaar"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:55
+msgid "The home page displaying Flathub apps"
+msgstr "Startsidan som visar Flathub-program"
+
+# TODO: Translatornote om att det är ett namn på https://flathub.org/en/apps/io.github.nokse22.Exhibit
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:59
+msgid "Exhibit app page"
+msgstr "Programsida för Exhibit"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:63
+msgid "Library page"
+msgstr "Bibliotekssida"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:67
+msgid "Search page"
+msgstr "Söksida"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:71
+msgid "Category page"
+msgstr "Kategorisida"
+
+#: src/bz-addon-tile.blp:64 src/bz-installed-tile.blp:55
+#: src/bz-rich-app-tile.blp:142
+msgid "Stopped Receiving Updates"
+msgstr "Har slutat ta emot uppdateringar"
+
+#: src/bz-addon-tile.c:168 src/bz-favorites-tile.c:155
+msgctxt "Install Controls"
+msgid "Uninstall"
+msgstr "Avinstallera"
+
+#: src/bz-addon-tile.c:170 src/bz-bundle-install-dialog.blp:148
+#: src/bz-bundle-install-dialog.blp:162 src/bz-favorites-tile.c:157
+#: src/bz-install-controls.wdgt:29
+msgctxt "Install Controls"
+msgid "Install"
+msgstr "Installera"
+
+#: src/bz-addons-dialog.blp:7
+msgid "Add-on"
+msgstr "Tillägg"
+
+#: src/bz-addons-dialog.blp:15 src/bz-addons-dialog.blp:22
+#: src/bz-addons-dialog.blp:71 src/bz-installed-tile.blp:96
+msgid "Manage Add-Ons"
+msgstr "Hantera tillägg"
+
+#: src/bz-addons-dialog.blp:81
+msgid "No Add-Ons Visible"
+msgstr "Inga tillägg synliga"
+
+#: src/bz-addons-dialog.blp:82
+msgid ""
+"Your current filter preferences are hiding all known add-ons. Try adjusting "
+"them."
+msgstr ""
+"Dina aktuella filterinställningar döljer alla kända tillägg. Försök justera dem."
+
+#: src/bz-addons-dialog.blp:89
+msgid "Add-on Page"
+msgstr "Tilläggssida"
+
+#: src/bz-addons-dialog.blp:205 src/bz-full-view.blp:408
+msgid "Downloads/Month"
+msgstr "Hämtningar/månad"
+
+#: src/bz-addons-dialog.blp:232 src/bz-full-view.blp:444
+msgid "Stopped Receiving Core Updates"
+msgstr "Har slutat ta emot kärnuppdateringar"
+
+#: src/bz-addons-dialog.blp:246
+msgid ""
+"This add-on uses a runtime that no longer receives updates or security fixes. "
+"It may become unsafe to use."
+msgstr ""
+"Detta tillägg använder en exekveringsmiljö som inte längre tar emot "
+"uppdateringar eller säkerhetsfixar. Det kan bli osäkert att använda."
+
+#: src/bz-addons-dialog.c:346
+#, c-format
+msgid "Add-on for %s"
+msgstr "Tillägg för %s"
+
+#: src/bz-addons-dialog.c:360 src/bz-full-view.c:618
+msgid "Show Less"
+msgstr "Visa mindre"
+
+#: src/bz-addons-dialog.c:360 src/bz-full-view.c:618 src/bz-section-view.blp:72
+msgid "Show More"
+msgstr "Visa mer"
+
+#: src/bz-addons-dialog.c:410
+msgid "Download Stats"
+msgstr "Hämtningsstatistik"
+
+#: src/bz-age-rating-dialog.blp:7 src/bz-age-rating-dialog.blp:31
+#: src/bz-age-rating-dialog.c:737 src/context-tile-callbacks.c:187
+#: src/context-tile-callbacks.c:194
+msgid "Age Rating"
+msgstr "Åldersklassificering"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:88
+msgid "Cartoon Violence"
+msgstr "Tecknat våld"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:90
+msgid "No information regarding cartoon violence"
+msgstr "Ingen information angående tecknat våld"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:94
+msgid "Fantasy Violence"
+msgstr "Orealistiskt våld"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:96
+msgid "No information regarding fantasy violence"
+msgstr "Ingen information angående orealistiskt våld"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:100
+msgid "Realistic Violence"
+msgstr "Realistiskt våld"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:102
+msgid "No information regarding realistic violence"
+msgstr "Ingen information angående realistiskt våld"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:106
+msgid "Violence Depicting Bloodshed"
+msgstr "Våld som skildrar blodsutgjutelse"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:108
+msgid "No information regarding bloodshed"
+msgstr "Ingen information angående blodsutgjutelse"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:112
+msgid "Sexual Violence"
+msgstr "Sexuellt våld"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:114
+msgid "No information regarding sexual violence"
+msgstr "Ingen information angående sexuellt våld"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:118
+msgid "Alcohol"
+msgstr "Alkohol"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:120
+msgid "No information regarding references to alcohol"
+msgstr "Ingen information angående referenser till alkohol"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:124
+msgid "Narcotics"
+msgstr "Narkotika"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:126
+msgid "No information regarding references to illicit drugs"
+msgstr "Ingen information angående referenser till illegala droger"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:130
+msgid "Tobacco"
+msgstr "Tobak"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:132
+msgid "No information regarding references to tobacco products"
+msgstr "Ingen information angående referenser till tobaksprodukter"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:136 src/bz-age-rating-dialog.c:475
+msgid "Nudity"
+msgstr "Nakenhet"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:138
+msgid "No information regarding nudity of any sort"
+msgstr "Ingen information angående nakenhet av något slag"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:142
+msgid "Sexual Themes"
+msgstr "Sexuella teman"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:144
+msgid "No information regarding references to or depictions of sexual nature"
+msgstr "Ingen information angående sexuella referenser eller skildringar"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:148
+msgid "Profanity"
+msgstr "Svordomar"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:150
+msgid "No information regarding profanity of any kind"
+msgstr "Ingen information angående svordomar av något slag"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:154
+msgid "Inappropriate Humor"
+msgstr "Olämplig humor"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:156
+msgid "No information regarding inappropriate humor"
+msgstr "Ingen information angående olämplig humor"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:160
+msgid "Discrimination"
+msgstr "Diskriminering"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:162
+msgid "No information regarding discriminatory language of any kind"
+msgstr "Ingen information angående diskriminerande språkbruk av något slag"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:166
+msgid "Advertising"
+msgstr "Annonser"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:168
+msgid "No information regarding advertising of any kind"
+msgstr "Ingen information angående annonser av något slag"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:172
+msgid "Gambling"
+msgstr "Hasardspel"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:174
+msgid "No information regarding gambling of any kind"
+msgstr "Ingen information angående hasardspel av något slag"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:178
+msgid "Purchasing"
+msgstr "Köp"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:180
+msgid "No information regarding the ability to spend money"
+msgstr "Ingen information angående möjlighet att spendera pengar"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:184
+msgid "Chat Between Users"
+msgstr "Chatt mellan användare"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:186
+msgid "No information regarding ways to chat with other users"
+msgstr "Ingen information angående sätt att chatta med andra användare"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:190
+msgid "Audio Chat Between Users"
+msgstr "Röstchatt mellan användare"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:192
+msgid "No information regarding ways to talk with other users"
+msgstr "Ingen information angående sätt att prata med andra användare"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:196
+msgid "Contact Details"
+msgstr "Kontaktdetaljer"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:198
+msgid ""
+"No information regarding sharing of social network usernames or email addresses"
+msgstr ""
+"Ingen information angående delning av e-postadresser eller användarnamn på "
+"sociala nätverk"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:202
+msgid "Identifying Information"
+msgstr "Identifierande information"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:204
+msgid "No information regarding sharing of user information with third parties"
+msgstr "Ingen information angående delning av användarinformation med tredje part"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:208
+msgid "Location Sharing"
+msgstr "Platsdelning"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:210
+msgid "No information regarding sharing of physical location with other users"
+msgstr "Ingen information angående delning av fysisk plats med andra användare"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:214
+msgid "Prostitution"
+msgstr "Prostitution"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:216
+msgid "No information regarding references to prostitution"
+msgstr "Ingen information angående referenser till prostitution"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:220
+msgid "Adultery"
+msgstr "Otrohet"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:222
+msgid "No information regarding references to adultery"
+msgstr "Ingen information angående referenser till otrohet"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:226
+msgid "Sexualized Characters"
+msgstr "Sexualiserade figurer"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:228
+msgid "No information regarding sexualized characters"
+msgstr "Ingen information angående sexualiserade figurer"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:232
+msgid "Desecration"
+msgstr "Skändning"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:234
+msgid "No information regarding references to desecration"
+msgstr "Ingen information angående referenser till skändning"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:238
+msgid "Human Remains"
+msgstr "Mänskliga kvarlevor"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:240
+msgid "No information regarding visible dead human remains"
+msgstr "Ingen information angående synliga kvarlevor av människor"
+
+#. TRANSLATORS: content rating title, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:244
+msgid "Slavery"
+msgstr "Slaveri"
+
+#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#: src/bz-age-rating-dialog.c:246
+msgid "No information regarding references to slavery"
+msgstr "Ingen information angående referenser till slaveri"
+
+#: src/bz-age-rating-dialog.c:424
+msgid "Does not include references to drugs"
+msgstr "Inkluderar inte referenser till droger"
+
+# TODO: grovt in gnome-software as well
+#: src/bz-age-rating-dialog.c:426
+msgid "Does not include swearing, profanity, and other kinds of strong language"
+msgstr "Inkluderar inte svärande, hädelse och andra typer av grovt språk"
+
+#: src/bz-age-rating-dialog.c:428
+msgid "Does not include ads or monetary transactions"
+msgstr "Inkluderar inte annonser eller pengaöverföring"
+
+#: src/bz-age-rating-dialog.c:430
+msgid "Does not include sex or nudity"
+msgstr "Inkluderar inte sex eller nakenhet"
+
+#: src/bz-age-rating-dialog.c:432
+msgid "Does not include uncontrolled chat functionality"
+msgstr "Inkluderar inte okontrollerad chattfunktion"
+
+#: src/bz-age-rating-dialog.c:434
+msgid "Does not include violence"
+msgstr "Inkluderar inte våld"
+
+#: src/bz-age-rating-dialog.c:469
+msgid "Drugs"
+msgstr "Droger"
+
+# TODO: grovt in gnome-software as well
+#: src/bz-age-rating-dialog.c:471
+msgid "Strong Language"
+msgstr "Grovt språk"
+
+#: src/bz-age-rating-dialog.c:473
+msgid "Money"
+msgstr "Pengar"
+
+#: src/bz-age-rating-dialog.c:477
+msgid "Social"
+msgstr "Socialt"
+
+#: src/bz-age-rating-dialog.c:479
+msgid "Violence"
+msgstr "Våld"
+
+#. Translators: Age rating format, e.g. "12+" for ages 12 and up
+#: src/bz-age-rating-dialog.c:686 src/context-tile-callbacks.c:177
+#, c-format
+msgid "%d+"
+msgstr "%d+"
+
+#: src/bz-age-rating-dialog.c:712
+msgctxt "Age rating"
+msgid "All"
+msgstr "Alla"
+
+#: src/bz-age-rating-dialog.c:748
+#, c-format
+msgid "%s has an unknown age rating"
+msgstr "%s har okänd åldersklassificering"
+
+#: src/bz-age-rating-dialog.c:754
+#, c-format
+msgid "%s is suitable for everyone"
+msgstr "%s passar för alla"
+
+#: src/bz-age-rating-dialog.c:757
+#, c-format
+msgid "%s is suitable for young children"
+msgstr "%s passar för unga barn"
+
+#: src/bz-age-rating-dialog.c:760
+#, c-format
+msgid "%s is suitable for children"
+msgstr "%s passar för barn"
+
+#: src/bz-age-rating-dialog.c:763
+#, c-format
+msgid "%s is suitable for teenagers"
+msgstr "%s passar för tonåringar"
+
+#: src/bz-age-rating-dialog.c:766
+#, c-format
+msgid "%s is suitable for adults"
+msgstr "%s passar för vuxna"
+
+#: src/bz-age-rating-dialog.c:769
+#, c-format
+msgid "%s is suitable for %s"
+msgstr "%s passar för %s"
+
+#: src/bz-age-rating-dialog.c:868
+#, c-format
+msgid "%s • %s"
+msgstr "%s • %s"
+
+#: src/bz-app-permissions.c:160
+#, c-format
+msgid "System folder %s"
+msgstr "Systemmapp %s"
+
+#: src/bz-app-permissions.c:162
+#, c-format
+msgid "Home subfolder %s"
+msgstr "Hemundermapp %s"
+
+#: src/bz-app-permissions.c:164
+msgid "Host system folders"
+msgstr "Värdsystemmappar"
+
+#: src/bz-app-permissions.c:166
+msgid "Host system configuration from /etc"
+msgstr "Värdsystemkonfiguration från /etc"
+
+#: src/bz-app-permissions.c:169
+#, c-format
+msgid "Desktop subfolder %s"
+msgstr "Skrivbordsundermapp %s"
+
+#: src/bz-app-permissions.c:170
+msgid "Desktop folder"
+msgstr "Skrivbordsmapp"
+
+#: src/bz-app-permissions.c:173
+#, c-format
+msgid "Documents subfolder %s"
+msgstr "Dokumentundermapp %s"
+
+#: src/bz-app-permissions.c:174
+msgid "Documents folder"
+msgstr "Dokumentmapp"
+
+#: src/bz-app-permissions.c:177
+#, c-format
+msgid "Music subfolder %s"
+msgstr "Musikundermapp %s"
+
+#: src/bz-app-permissions.c:178
+msgid "Music folder"
+msgstr "Musikmapp"
+
+#: src/bz-app-permissions.c:181
+#, c-format
+msgid "Pictures subfolder %s"
+msgstr "Bildundermapp %s"
+
+#: src/bz-app-permissions.c:182
+msgid "Pictures folder"
+msgstr "Bildmapp"
+
+#: src/bz-app-permissions.c:185
+#, c-format
+msgid "Public Share subfolder %s"
+msgstr "Delningsundermapp %s"
+
+#: src/bz-app-permissions.c:186
+msgid "Public Share folder"
+msgstr "Delningsmapp"
+
+#: src/bz-app-permissions.c:189
+#, c-format
+msgid "Videos subfolder %s"
+msgstr "Videoundermapp %s"
+
+#: src/bz-app-permissions.c:190
+msgid "Videos folder"
+msgstr "Videomapp"
+
+#: src/bz-app-permissions.c:193
+#, c-format
+msgid "Templates subfolder %s"
+msgstr "Mallundermapp %s"
+
+#: src/bz-app-permissions.c:194
+msgid "Templates folder"
+msgstr "Mallmapp"
+
+#: src/bz-app-permissions.c:197
+#, c-format
+msgid "User cache subfolder %s"
+msgstr "Användarcacheundermapp %s"
+
+#: src/bz-app-permissions.c:198
+msgid "User cache folder"
+msgstr "Användarcachemapp"
+
+#: src/bz-app-permissions.c:201
+#, c-format
+msgid "User configuration subfolder %s"
+msgstr "Användarkonfigurationsundermapp %s"
+
+#: src/bz-app-permissions.c:202
+msgid "User configuration folder"
+msgstr "Användarkonfigurationsmapp"
+
+#: src/bz-app-permissions.c:205
+#, c-format
+msgid "User data subfolder %s"
+msgstr "Användardataundermapp %s"
+
+#: src/bz-app-permissions.c:206
+msgid "User data folder"
+msgstr "Användardatamapp"
+
+# TODO: in gnome-software as well
+#: src/bz-app-permissions.c:209
+#, c-format
+msgid "User runtime subfolder %s"
+msgstr "Användarexekveringsmiljöundermapp %s"
+
+# TODO: in gnome-software as well
+#: src/bz-app-permissions.c:210
+msgid "User runtime folder"
+msgstr "Användarexekveringsmiljömapp"
+
+#: src/bz-app-permissions.c:212
+#, c-format
+msgid "Filesystem access to %s"
+msgstr "Filsystemsåtkomst till %s"
+
+#: src/bz-app-permissions.c:214
+msgid "Unknown filesystem path"
+msgstr "Okänd filsystemssökväg"
+
+#: src/bz-app-size-dialog.blp:30 src/bz-app-size-dialog.blp:71
+msgid "Download Size"
+msgstr "Hämtningsstorlek"
+
+#: src/bz-app-size-dialog.blp:40 src/bz-app-size-dialog.blp:99
+msgid "Installed Size"
+msgstr "Installerad storlek"
+
+#: src/bz-app-size-dialog.blp:72
+msgid "Amount to download from the internet"
+msgstr "Mängd att hämta från internet"
+
+#: src/bz-app-size-dialog.blp:100
+msgid "Size on Disk"
+msgstr "Storlek på disk"
+
+#: src/bz-app-size-dialog.blp:203
+msgid "Open user data folder"
+msgstr "Öppna användardatamapp"
+
+#: src/bz-app-size-dialog.blp:213
+msgid "Your User Data"
+msgstr "Dina användardata"
+
+#: src/bz-app-size-dialog.blp:214
+msgid "Caches, settings, and other app data"
+msgstr "Cachar, inställningar och andra programdata"
+
+#: src/bz-app-size-dialog.blp:234
+msgid "Cache"
+msgstr "Cache"
+
+#: src/bz-app-size-dialog.blp:235
+msgid "Temporary cached data"
+msgstr "Tillfälligt cachade data"
+
+#: src/bz-app-size-dialog.blp:247
+msgid "Clear Cache"
+msgstr "Töm cache"
+
+#: src/bz-app-size-dialog.c:99
+msgid "Installed Runtime Size"
+msgstr "Installerad storlek för exekveringsmiljö"
+
+#: src/bz-app-size-dialog.c:99
+msgid "Runtime Download Size"
+msgstr "Hämtningsstorlek för exekveringsmiljö"
+
+#: src/bz-app-size-dialog.c:111 src/bz-bundle-install-dialog.c:185
+#: src/context-tile-callbacks.c:104 src/context-tile-callbacks.c:394
+#: src/context-tile-callbacks.c:416
+msgid "N/A"
+msgstr "-"
+
+#: src/bz-app-size-dialog.c:195 src/bz-app-size-dialog.c:208
+msgid "Storage"
+msgstr "Lagring"
+
+#: src/bz-app-tile.blp:56 src/bz-developer-badge.c:98 src/bz-rich-app-tile.blp:106
+#: src/bz-rich-app-tile.c:443
+msgid "Verified"
+msgstr "Verifierat"
+
+#. Translators: As in 'The app is installed'.
+#: src/bz-app-tile.blp:87 src/bz-releases-list.c:206
+#: src/context-tile-callbacks.c:136
+msgid "Installed"
+msgstr "Installerat"
+
+#. Translators: Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
+#: src/bz-application.c:774
+msgid "translator-credits"
+msgstr ""
+"Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
+"Skicka synpunkter på översättningen till <tp-sv@listor.tp-sv.se>"
+
+#: src/bz-application.c:784
+msgid "Special Thanks"
+msgstr "Tack till"
+
+#: src/bz-application.c:842
+msgid "Logged Out Successfully!"
+msgstr "Loggade ut!"
+
+#: src/bz-application.c:1048
+msgid "Ubuntu Troubles!"
+msgstr "Ubuntu-problem!"
+
+#: src/bz-application.c:1051
+msgid ""
+"Ubuntu 25.10 and newer have messed up default security rules, making it "
+"<b>impossible to install apps</b> from the Flatpak version of Bazaar, please "
+"just use the normal package for now by using\n"
+"\n"
+"<tt>sudo apt install bazaar</tt>\n"
+"\n"
+"You can then remove this Flatpak version with\n"
+"\n"
+"<tt>flatpak uninstall io.github.kolunmi.Bazaar</tt>"
+msgstr ""
+"Ubuntu 25.10 och nyare har felaktiga standardsäkerhetsregler, vilket gör det "
+"<b>omöjligt att installera program</b> från Flatpak-versionen av Bazaar, använd "
+"för närvarande det vanliga paketet genom att använda\n"
+"\n"
+"<tt>sudo apt install bazaar</tt>\n"
+"\n"
+"Du kan sedan ta bort denna Flatpak-version med\n"
+"\n"
+"<tt>flatpak uninstall io.github.kolunmi.Bazaar</tt>"
+
+#: src/bz-application.c:1057
+msgid "Continue Anyway"
+msgstr "Fortsätt ändå"
+
+#: src/bz-application.c:1073
+msgid "Performing setup…"
+msgstr "Genomför konfiguration…"
+
+#: src/bz-application.c:1172
+msgid "Set Up System Flathub?"
+msgstr "Konfigurera systemets Flathub?"
+
+#: src/bz-application.c:1175
+msgid ""
+"The system Flathub remote is not set up. Bazaar requires Flathub to be "
+"configured on the system Flatpak installation to browse and install "
+"applications.\n"
+"\n"
+"You can still use Bazaar to browse and remove already installed apps."
+msgstr ""
+"Systemets Flathub-fjärr är inte konfigurerad. Bazaar kräver att Flathub är "
+"konfigurerat i systemets Flatpak-installation för att bläddra bland och "
+"installera program.\n"
+"\n"
+"Du kan fortfarande använda Bazaar för att bläddra bland och ta bort redan "
+"installerade program."
+
+#: src/bz-application.c:1182
+msgid "Set Up Flathub?"
+msgstr "Konfigurera Flathub?"
+
+#: src/bz-application.c:1185
+msgid ""
+"Flathub is not set up on this system. You will not be able to browse and "
+"install applications in Bazaar if its unavailable.\n"
+"\n"
+"You can still use Bazaar to browse and remove already installed apps."
+msgstr ""
+"Flathub är inte konfigurerat på detta system. Du kommer inte kunna bläddra "
+"bland och installera program i Bazaar om det är otillgängligt.\n"
+"\n"
+"Du kan fortfarande använda Bazaar för att bläddra bland och ta bort redan "
+"installerade program."
+
+#: src/bz-application.c:1191
+msgid "Later"
+msgstr "Senare"
+
+#: src/bz-application.c:1192
+msgid "Set Up Flathub"
+msgstr "Konfigurera Flathub"
+
+#: src/bz-application.c:1726
+msgid "A backend error occurred"
+msgstr "Ett bakändesfel inträffade"
+
+#: src/bz-application.c:1934 src/bz-application.c:4205
+msgid "Refreshing…"
+msgstr "Uppdaterar…"
+
+#: src/bz-application.c:2098
+#, c-format
+msgid "Loading %d apps…"
+msgstr "Läser in %d program…"
+
+#: src/bz-application.c:2151 src/bz-application.c:2225
+msgid "Failed to open file"
+msgstr "Misslyckades med att öppna fil"
+
+#: src/bz-application.c:2239
+msgid "Failed to load metainfo"
+msgstr "Misslyckades med att läsa in metainfo"
+
+#: src/bz-application.c:2333
+msgid "An initialization error occurred"
+msgstr "Ett initieringsfel inträffade"
+
+#: src/bz-application.c:2732
+msgid "Checking for updates…"
+msgstr "Letar efter uppdateringar…"
+
+#: src/bz-application.c:2788
+msgid "Failed to check for updates"
+msgstr "Misslyckades med att leta efter uppdateringar"
+
+#: src/bz-application.c:3976
+msgid "Malformed Link"
+msgstr "Felformaterad länk"
+
+#: src/bz-application.c:3977
+msgid ""
+"The link used to open this app has incorrect capitalization and may stop "
+"working in the future.\n"
+"\n"
+"This is most likely caused by KRunner sending incorrect app IDs"
+msgstr ""
+"Länken som används för att öppna detta program har oriktig versalisering och "
+"kan sluta fungera i framtiden.\n"
+"\n"
+"Detta orsakas troligen av att KRunner skickar felaktiga program-ID:n"
+
+#: src/bz-application.c:3985
+msgid "Could not find app"
+msgstr "Kunde inte hitta program"
+
+#: src/bz-application.c:4202
+#, c-format
+msgid "Loading %d app…"
+msgid_plural "Loading %d apps…"
+msgstr[0] "Läser in %d program…"
+msgstr[1] "Läser in %d program…"
+
+#: src/bz-application.c:4207
+msgid "Writing to cache…"
+msgstr "Skriver till cache…"
+
+#: src/bz-apps-page.blp:97
+msgid "Show All"
+msgstr "Visa alla"
+
+#: src/bz-apps-page.c:214
+#, c-format
+msgid "All \"%s\""
+msgstr "Alla ”%s”"
+
+#: src/bz-apps-page.c:462 src/bz-subcategory-list.c:89
+#, c-format
+msgid "%d Applications"
+msgstr "%d program"
+
+#: src/bz-article.blp:86
+msgid "Failed to Load Article"
+msgstr "Misslyckades med att läsa in artikel"
+
+#: src/bz-bundle-install-dialog.blp:21 src/bz-bundle-install-dialog.blp:27
+msgid "Bundle Installation"
+msgstr "Installation av bunt"
+
+#: src/bz-bundle-install-dialog.blp:198
+msgid "Additional dependencies may take extra space"
+msgstr "Ytterligare beroenden kan ta extra utrymme"
+
+#: src/bz-bundle-install-dialog.blp:232
+msgid ""
+"Installing this app may require adding a new software source. Other apps from "
+"this source will show up in Bazaar.\n"
+"\n"
+"Only add this source if you're sure you trust it."
+msgstr ""
+"Att installera detta program kan kräva tillägg av en ny programvarukälla. Andra "
+"program från denna källa kommer visas i Bazaar.\n"
+"\n"
+"Lägg endast till denna källa om du är säker på att du litar på den."
+
+#: src/bz-bundle-install-dialog.blp:412
+msgid "Successfully Installed!"
+msgstr "Installerades!"
+
+#. TRANSLATORS: Button to launch an installed app
+#: src/bz-bundle-install-dialog.blp:438 src/bz-bundle-install-dialog.blp:524
+#: src/bz-rich-app-tile.blp:199 src/bz-transaction-tile.blp:299
+msgid "Open"
+msgstr "Öppna"
+
+#: src/bz-bundle-install-dialog.blp:448 src/bz-bundle-install-dialog.blp:534
+msgid "Show App Details"
+msgstr "Visa programdetaljer"
+
+#: src/bz-bundle-install-dialog.blp:499
+msgid "Already Installed"
+msgstr "Redan installerat"
+
+#: src/bz-bundle-install-dialog.blp:546
+msgid "Installation Failed"
+msgstr "Installationen misslyckades"
+
+#: src/bz-bundle-install-dialog.c:168
+msgid "Unknown install size"
+msgstr "Okänd installationsstorlek"
+
+#: src/bz-bundle-install-dialog.c:171
+#, c-format
+msgid "About %s to install"
+msgstr "Ungefär %s att installera"
+
+#: src/bz-bundle-install-dialog.c:214
+msgid "No special permissions"
+msgstr "Inga speciella rättigheter"
+
+#: src/bz-curated-view.blp:27
+msgid "No Curation"
+msgstr "Inget urval"
+
+#: src/bz-curated-view.blp:29
+msgid ""
+"There is no curation information provided on this system. You can still browse "
+"apps on Flathub"
+msgstr ""
+"Ingen urvalsinformation tillhandahålls på detta system. Du kan fortfarande "
+"bläddra bland program på Flathub"
+
+#: src/bz-curated-view.blp:33
+msgid "Browse Flathub"
+msgstr "Bläddra på Flathub"
+
+#: src/bz-curated-view.blp:49
+msgid "Offline"
+msgstr "Frånkopplad"
+
+#: src/bz-developer-badge.c:94 src/bz-developer-badge.c:98
+msgid "Not Verified"
+msgstr "Inte verifierad"
+
+#: src/bz-developer-badge.c:213
+msgid "Developer information not available."
+msgstr "Utvecklarinformation är inte tillgänglig."
+
+#: src/bz-developer-badge.c:219 src/bz-developer-badge.c:233
+#, c-format
+msgid ""
+"The ownership of the %s app ID has not been verified and it may be a community "
+"package."
+msgstr ""
+"Ägarskapet till program-ID:t %s har inte verifierats, det kan vara ett "
+"gemensamhetspaket."
+
+#: src/bz-developer-badge.c:237
+#, c-format
+msgid ""
+"The ownership of the %s app ID has been manually verified by the Flathub team."
+msgstr ""
+"Ägarskapet till program-ID:t %s har verifierats manuellt av Flathub-gruppen."
+
+#: src/bz-developer-badge.c:253
+#, c-format
+msgid ""
+"The ownership of the %1$s app ID has been verified by <b>%2$s</b> on <b>%3$s</"
+"b>."
+msgstr ""
+"Ägarskapet till program-ID:t %1$s har verifierats av <b>%2$s</b> på <b>%3$s</b>."
+
+#: src/bz-developer-badge.c:260
+#, c-format
+msgid "The ownership of the %1$s app ID has been verified using %2$s."
+msgstr "Ägarskapet till program-ID:t %1$s har verifierats med %2$s."
+
+#: src/bz-developer-badge.c:264
+#, c-format
+msgid "The ownership of the %s app ID has been verified."
+msgstr "Ägarskapet till program-ID:t %s har verifierats."
+
+#: src/bz-donations-dialog.blp:7
+msgid "Bazaar Release"
+msgstr "Bazaar-utgåva"
+
+#: src/bz-donations-dialog.blp:77
+msgid "Full Release Notes"
+msgstr "Fullständiga kommentarer till utgåva"
+
+#: src/bz-donations-dialog.blp:112
+msgid "This release was made possible by users like you!"
+msgstr "Denna utgåva gjordes möjlig av användare som du!"
+
+#: src/bz-donations-dialog.blp:121
+msgid ""
+"I love making Bazaar, but I cannot do it alone. Help support further "
+"development by donating on Ko-Fi."
+msgstr ""
+"Jag älskar att skapa Bazaar, men kan inte göra det själv. Stöd vidare "
+"utveckling genom att donera på Ko-Fi."
+
+#: src/bz-donations-dialog.blp:136
+msgid "Donate to Bazaar"
+msgstr "Donera till Bazaar"
+
+#. Translators: the %s format specifier will be something along the lines of "0.7.6" etc
+#: src/bz-donations-dialog.c:228
+#, c-format
+msgid "What's New in %s?"
+msgstr "Vad är nytt i %s?"
+
+#. Translators: this is a release date label, like "Released February 9, 2026"
+#: src/bz-donations-dialog.c:244
+msgid "Released %B %-e, %Y"
+msgstr "Släppt %-e %B, %Y"
+
+#: src/bz-entry-group-util.c:73
+msgid "Choose an Installation"
+msgstr "Välj en installation"
+
+#: src/bz-entry-group-util.c:76
+msgid ""
+"You have multiple versions of this app installed. Which one would you like to "
+"proceed with?"
+msgstr ""
+"Du har flera versioner av detta program installerade. Vilken vill du fortsätta "
+"med?"
+
+#: src/bz-entry-group-util.c:80 src/bz-rich-app-tile.blp:233
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: src/bz-entry-selection-row.blp:17
+msgid "For This User Only"
+msgstr "Endast för denna användare"
+
+#: src/bz-entry-selection-row.c:112
+msgid "this user"
+msgstr "denna användare"
+
+#: src/bz-entry-selection-row.c:112
+msgid "all users"
+msgstr "alla användare"
+
+#: src/bz-error-dialog.blp:36 src/bz-safety-dialog.blp:100 src/error.c:69
+#: src/error.c:88
+msgid "Details"
+msgstr "Detaljer"
+
+#. TRANSLATORS: tooltip for a button that copies text to the clipboard
+#: src/bz-error-dialog.blp:48
+msgid "Copy"
+msgstr "Kopiera"
+
+#: src/bz-error-dialog.c:56 src/bz-screenshot-page.c:446 src/bz-share-list.c:364
+msgid "Copied!"
+msgstr "Kopierad!"
+
+#: src/bz-favorite-button.blp:14
+msgid "Favorite Count"
+msgstr "Antal favoriter"
+
+#: src/bz-favorite-button.c:388
+msgid "Failed to update favorite"
+msgstr "Misslyckades med att uppdatera favorit"
+
+#: src/bz-favorite-button.c:434
+msgid "Log in with Flathub to manage favorites"
+msgstr "Logga in med Flathub för att hantera favoriter"
+
+#: src/bz-favorite-button.c:440
+msgid "Log In"
+msgstr "Logga in"
+
+#: src/bz-favorites-page.blp:5 src/bz-window.blp:348
+msgid "Favorites"
+msgstr "Favoriter"
+
+#: src/bz-favorites-page.blp:17 src/bz-section-view.blp:87
+msgid "Install All"
+msgstr "Installera alla"
+
+#: src/bz-favorites-page.blp:47
+msgid "No Favorites"
+msgstr "Inga favoriter"
+
+#: src/bz-favorites-page.blp:48
+msgid "Applications you mark as favorite will appear here"
+msgstr "Program som du märkt som favorit kommer visas här"
+
+#: src/bz-favorites-tile.blp:60
+msgid "Support This Application"
+msgstr "Stöd detta programm"
+
+#: src/bz-favorites-tile.blp:109
+msgid "Remove From Favorites"
+msgstr "Ta bort från favoriter"
+
+#: src/bz-favorites-tile.c:353
+msgid "Failed to remove favorite"
+msgstr "Misslyckades med att ta bort favorit"
+
+#: src/bz-featured-carousel.blp:32
+msgid "Previous"
+msgstr "Föregående"
+
+#: src/bz-featured-carousel.blp:55
+msgid "Next"
+msgstr "Nästa"
+
+#: src/bz-flathub-category.c:95
+msgid "Editing"
+msgstr "Redigering"
+
+#: src/bz-flathub-category.c:96
+msgid "Midi"
+msgstr "Midi"
+
+#: src/bz-flathub-category.c:97
+msgid "Mixer"
+msgstr "Mixer"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-flathub-category.c:98 src/bz-search-pill-list.c:77
+msgid "Music"
+msgstr "Musik"
+
+#: src/bz-flathub-category.c:99
+msgid "Player"
+msgstr "Spelare"
+
+#: src/bz-flathub-category.c:100
+msgid "Recorder"
+msgstr "Inspelare"
+
+#: src/bz-flathub-category.c:101
+msgid "Sequencer"
+msgstr "Sequencer"
+
+#: src/bz-flathub-category.c:102
+msgid "Tuner"
+msgstr "Stämapparat"
+
+#: src/bz-flathub-category.c:103
+msgid "TV"
+msgstr "TV"
+
+#: src/bz-flathub-category.c:108
+msgid "Emulation"
+msgstr "Emulering"
+
+#: src/bz-flathub-category.c:109
+msgid "Action"
+msgstr "Action"
+
+#: src/bz-flathub-category.c:110
+msgid "Adventure"
+msgstr "Äventyr"
+
+#: src/bz-flathub-category.c:111
+msgid "Arcade"
+msgstr "Arkad"
+
+#: src/bz-flathub-category.c:112
+msgid "Blocks"
+msgstr "Klossar"
+
+#: src/bz-flathub-category.c:113
+msgid "Board"
+msgstr "Brädspel"
+
+#: src/bz-flathub-category.c:114
+msgid "Card"
+msgstr "Kort"
+
+#: src/bz-flathub-category.c:115
+msgid "Kids"
+msgstr "Barn"
+
+#: src/bz-flathub-category.c:116
+msgid "Logic"
+msgstr "Logik"
+
+#: src/bz-flathub-category.c:117
+msgid "Role Playing"
+msgstr "Rollspel"
+
+#: src/bz-flathub-category.c:118
+msgid "Shooter"
+msgstr "Skjutspel"
+
+#: src/bz-flathub-category.c:119
+msgid "Simulation"
+msgstr "Simulering"
+
+#: src/bz-flathub-category.c:120
+msgid "Sports"
+msgstr "Sport"
+
+#: src/bz-flathub-category.c:121
+msgid "Strategy"
+msgstr "Strategi"
+
+#: src/bz-flathub-category.c:126
+msgid "Browsers"
+msgstr "Webbläsare"
+
+#: src/bz-flathub-category.c:127
+msgid "Chat"
+msgstr "Chatt"
+
+#: src/bz-flathub-category.c:128
+msgid "Mail"
+msgstr "E-post"
+
+#: src/bz-flathub-category.c:129
+msgid "File Sharing"
+msgstr "Fildelning"
+
+#: src/bz-flathub-category.c:134
+msgid "Audio & Video"
+msgstr "Ljud och video"
+
+#: src/bz-flathub-category.c:134
+msgid "Media"
+msgstr "Media"
+
+#: src/bz-flathub-category.c:134
+msgid "More Audio & Video"
+msgstr "Mer ljud och video"
+
+#: src/bz-flathub-category.c:135
+msgid "Developer Tools"
+msgstr "Utvecklarverktyg"
+
+#: src/bz-flathub-category.c:135
+msgid "Develop"
+msgstr "Utveckla"
+
+#: src/bz-flathub-category.c:135
+msgid "More Developer Tools"
+msgstr "Mer utvecklarverktyg"
+
+#: src/bz-flathub-category.c:136
+msgid "Education"
+msgstr "Utbildning"
+
+#: src/bz-flathub-category.c:136
+msgid "Learn"
+msgstr "Lär dig"
+
+#: src/bz-flathub-category.c:136
+msgid "More Education"
+msgstr "Mer utbildning"
+
+#: src/bz-flathub-category.c:137
+msgid "Gaming"
+msgstr "Spelande"
+
+#: src/bz-flathub-category.c:137
+msgid "Play"
+msgstr "Spela"
+
+#: src/bz-flathub-category.c:137
+msgid "More Gaming"
+msgstr "Mer spelande"
+
+#: src/bz-flathub-category.c:138
+msgid "Graphics & Photography"
+msgstr "Grafik och fotografi"
+
+#: src/bz-flathub-category.c:138
+msgid "Create"
+msgstr "Skapa"
+
+#: src/bz-flathub-category.c:138
+msgid "More Graphics & Photography"
+msgstr "Mer grafik och fotografi"
+
+#: src/bz-flathub-category.c:139
+msgid "Networking"
+msgstr "Nätverk"
+
+#: src/bz-flathub-category.c:139
+msgid "Internet"
+msgstr "Internet"
+
+#: src/bz-flathub-category.c:139
+msgid "More Networking"
+msgstr "Mer nätverk"
+
+#: src/bz-flathub-category.c:140
+msgid "Productivity"
+msgstr "Produktivitet"
+
+#: src/bz-flathub-category.c:140
+msgid "Work"
+msgstr "Arbete"
+
+#: src/bz-flathub-category.c:140
+msgid "More Productivity"
+msgstr "Mer produktivitet"
+
+#: src/bz-flathub-category.c:141
+msgid "Science"
+msgstr "Vetenskap"
+
+#: src/bz-flathub-category.c:141
+msgid "More Science"
+msgstr "Mer vetenskap"
+
+#: src/bz-flathub-category.c:142
+msgid "System"
+msgstr "System"
+
+#: src/bz-flathub-category.c:142
+msgid "More System"
+msgstr "Mer system"
+
+#: src/bz-flathub-category.c:143
+msgid "Utilities"
+msgstr "Nyttoprogram"
+
+#: src/bz-flathub-category.c:143 src/bz-flathub-page.blp:434
+msgid "Tools"
+msgstr "Verktyg"
+
+#: src/bz-flathub-category.c:143
+msgid "More Utilities"
+msgstr "Mer nyttoprogram"
+
+#: src/bz-flathub-category.c:144 src/bz-flathub-page.blp:106
+#: src/bz-flathub-page.blp:138
+msgid "Trending"
+msgstr "Trendande"
+
+#: src/bz-flathub-category.c:144
+msgid "More Trending"
+msgstr "Mer trendande"
+
+#: src/bz-flathub-category.c:145 src/bz-flathub-page.blp:112
+#: src/bz-flathub-page.blp:171
+msgid "Popular"
+msgstr "Populärt"
+
+#: src/bz-flathub-category.c:145
+msgid "More Popular"
+msgstr "Mer populärt"
+
+#: src/bz-flathub-category.c:146 src/bz-flathub-page.blp:160
+msgid "Recently Added"
+msgstr "Senast tillagt"
+
+#: src/bz-flathub-category.c:146 src/bz-flathub-page.blp:118
+msgid "New"
+msgstr "Nytt"
+
+#: src/bz-flathub-category.c:146
+msgid "More New"
+msgstr "Mer nytt"
+
+#: src/bz-flathub-category.c:147 src/bz-flathub-page.blp:149
+msgid "Recently Updated"
+msgstr "Senast uppdaterat"
+
+#: src/bz-flathub-category.c:147 src/bz-flathub-page.blp:124
+msgid "Updated"
+msgstr "Uppdaterat"
+
+#: src/bz-flathub-category.c:147
+msgid "More Updated"
+msgstr "Mer uppdaterat"
+
+#: src/bz-flathub-category.c:148
+msgid "Mobile"
+msgstr "Mobil"
+
+#: src/bz-flathub-category.c:148
+msgid "More Mobile"
+msgstr "Mer mobil"
+
+#: src/bz-flathub-category.c:149
+msgid "Adwaita"
+msgstr "Adwaita"
+
+#: src/bz-flathub-category.c:149
+msgid "More Adwaita"
+msgstr "Mer Adwaita"
+
+#: src/bz-flathub-category.c:150
+msgid "KDE Apps"
+msgstr "KDE-program"
+
+#: src/bz-flathub-category.c:150
+msgid "More KDE Apps"
+msgstr "Mer KDE-program"
+
+#: src/bz-flathub-category.c:151 src/bz-flathub-page.blp:416
+msgid "Games"
+msgstr "Spel"
+
+#: src/bz-flathub-category.c:151 src/bz-flathub-page.blp:476
+msgid "More Games"
+msgstr "Mer spel"
+
+#: src/bz-flathub-category.c:152 src/bz-flathub-page.blp:422
+msgid "Emulators"
+msgstr "Emulatorer"
+
+#: src/bz-flathub-category.c:152
+msgid "More Emulators"
+msgstr "Mer emulatorer"
+
+#: src/bz-flathub-category.c:153 src/bz-flathub-page.blp:428
+msgid "Launchers"
+msgstr "Startare"
+
+#: src/bz-flathub-category.c:153
+msgid "More Game Launchers"
+msgstr "Mer spelstartare"
+
+#: src/bz-flathub-category.c:154
+msgid "Game Tools"
+msgstr "Spelverktyg"
+
+#: src/bz-flathub-category.c:154
+msgid "More Game Tools"
+msgstr "Mer spelverktyg"
+
+#: src/bz-flathub-page.blp:22
+msgid "Flathub Not Added"
+msgstr "Flathub lades inte till"
+
+#: src/bz-flathub-page.blp:23
+msgid "The Flathub remote was not found on any of your Flatpak installations"
+msgstr "Flathub-fjärren hittades inte på någon av dina Flatpak-installationer"
+
+#: src/bz-flathub-page.blp:32
+msgid "Can't Reach Flathub"
+msgstr "Kommer inte åt Flathub"
+
+#: src/bz-flathub-page.blp:33
+msgid "You can still manage and search for apps."
+msgstr "Du kan fortfarande hantera och söka program."
+
+#: src/bz-flathub-page.blp:39
+msgid "Search Apps"
+msgstr "Sök program"
+
+#: src/bz-flathub-page.blp:50
+msgid "Reconnect"
+msgstr "Anslut igen"
+
+#: src/bz-flathub-page.blp:199
+msgid "App of the Day"
+msgstr "Dagens program"
+
+#: src/bz-flathub-page.blp:262
+msgid "On the Go"
+msgstr "I farten"
+
+#: src/bz-flathub-page.blp:274
+msgid "Apps for your Linux phones and tablets"
+msgstr "Program för dina Linux-telefoner och plattor"
+
+#: src/bz-flathub-page.blp:285 src/bz-flathub-page.blp:320
+msgid "More Mobile Apps"
+msgstr "Fler mobilappar"
+
+#: src/bz-flathub-page.blp:378
+msgid "We​ ♥​ Games"
+msgstr "Vi​ ♥​ spel"
+
+#: src/bz-flathub-page.blp:391
+msgid "Games and apps to run your favorite titles"
+msgstr "Spel och program för att köra dina favorittitlar"
+
+#: src/bz-full-view.blp:33
+msgid "No Results"
+msgstr "Inga resultat"
+
+#: src/bz-full-view.blp:34
+msgid "Try a different search query"
+msgstr "Försök med en annan sökning"
+
+#: src/bz-full-view.blp:103
+msgid ""
+"This is a local preview, some details may differ from the published listing"
+msgstr ""
+"Detta är en lokal förhandsgranskning, vissa detaljer kan skilja sig från den "
+"publicerade posten"
+
+#: src/bz-full-view.blp:106
+msgid "Preview Store Appearance"
+msgstr "Förhandsgranska butiksutseende"
+
+#: src/bz-full-view.blp:233
+msgid "_Support"
+msgstr "_Stöd"
+
+#: src/bz-full-view.blp:458
+msgid ""
+"This app uses a runtime that no longer receives updates or security fixes. It "
+"may become unsafe to use."
+msgstr ""
+"Detta program använder en exekveringsmiljö som inte längre tar emot "
+"uppdateringar eller säkerhetsfixar. Det kan bli osäkert att använda."
+
+#: src/bz-full-view.blp:536
+msgid "Trash Data"
+msgstr "Kasta data i papperskorgen"
+
+#: src/bz-full-view.blp:599
+msgid "Add-ons"
+msgstr "Tillägg"
+
+#: src/bz-full-view.blp:634
+msgid "More Add-Ons"
+msgstr "Mer tillägg"
+
+#: src/bz-full-view.blp:645
+msgid "Links"
+msgstr "Länkar"
+
+#: src/bz-full-view.blp:676
+msgid "Similar Apps"
+msgstr "Liknande program"
+
+#: src/bz-full-view.c:181
+msgid "No URL"
+msgstr "Ingen URL"
+
+#: src/bz-full-view.c:199
+msgid ""
+"This app has a FLOSS license, meaning the source code can be audited for safety."
+msgstr ""
+"Detta program har en FLOSS-licens (fri programvara med öppen källkod), vilket "
+"betyder att källkoden kan säkerhetsgranskas."
+
+#: src/bz-full-view.c:200
+msgid ""
+"This app has a proprietary license, meaning the source code is developed "
+"privately and cannot be audited by an independent third party."
+msgstr ""
+"Detta program har en proprietär licens, vilket betyder att källkoden utvecklas "
+"privat och inte kan granskas av en oberoende tredje part."
+
+#: src/bz-full-view.c:207
+msgid "More Apps"
+msgstr "Mer program"
+
+#: src/bz-full-view.c:208
+#, c-format
+msgid "More Apps by %s"
+msgstr "Mer program av %s"
+
+#: src/bz-full-view.c:215
+msgid "Other Apps by this Developer"
+msgstr "Andra program av denna utvecklare"
+
+#: src/bz-full-view.c:217 src/bz-full-view.c:309
+#, c-format
+msgid "Other Apps by %s"
+msgstr "Andra program av %s"
+
+#: src/bz-full-view.c:226
+#, c-format
+msgid "%s is not installed, but it still has <b>%s</b> of data present."
+msgstr "%s är inte installerat men har fortfarande kvar <b>%s</b> data."
+
+#: src/bz-full-view.c:311
+msgid "Other Apps"
+msgstr "Andra program"
+
+#: src/bz-full-view.c:313
+#, c-format
+msgid "%d Application"
+msgid_plural "%d Applications"
+msgstr[0] "%d program"
+msgstr[1] "%d program"
+
+#: src/bz-full-view.c:498 src/bz-user-data-tile.c:160
+msgid "Failed to Remove User Data"
+msgstr "Misslyckades med att ta bort användardata"
+
+#: src/bz-hardware-support-dialog.blp:7 src/bz-hardware-support-dialog.blp:31
+msgid "Hardware Support"
+msgstr "Hårdvarustöd"
+
+#: src/bz-hardware-support-dialog.c:62
+msgid "Keyboard support"
+msgstr "Tangentbordsstöd"
+
+#: src/bz-hardware-support-dialog.c:64
+msgid "Requires keyboards"
+msgstr "Kräver tangentbord"
+
+#: src/bz-hardware-support-dialog.c:65
+msgid "Recommends keyboards"
+msgstr "Rekommenderar tangentbord"
+
+#: src/bz-hardware-support-dialog.c:66
+msgid "Supports keyboards"
+msgstr "Stöder tangentbord"
+
+#: src/bz-hardware-support-dialog.c:67
+msgid "Unknown support for keyboards"
+msgstr "Okänt stöd för tangentbord"
+
+#: src/bz-hardware-support-dialog.c:69
+msgid "Mouse support"
+msgstr "Musstöd"
+
+#: src/bz-hardware-support-dialog.c:71
+msgid "Requires mice or pointing devices"
+msgstr "Kräver möss eller pekdon"
+
+#: src/bz-hardware-support-dialog.c:72
+msgid "Recommends mice or pointing devices"
+msgstr "Rekommenderar möss eller pekdon"
+
+#: src/bz-hardware-support-dialog.c:73
+msgid "Supports mice or pointing devices"
+msgstr "Stöder möss eller pekdon"
+
+#: src/bz-hardware-support-dialog.c:74
+msgid "Unknown support for mice or pointing devices"
+msgstr "Okänt stöd för möss eller pekdon"
+
+#: src/bz-hardware-support-dialog.c:76
+msgid "Touchscreen support"
+msgstr "Pekskärmsstöd"
+
+#: src/bz-hardware-support-dialog.c:78
+msgid "Requires touchscreens"
+msgstr "Kräver pekskärmar"
+
+#: src/bz-hardware-support-dialog.c:79
+msgid "Recommends touchscreens"
+msgstr "Rekommenderar pekskärmar"
+
+#: src/bz-hardware-support-dialog.c:80
+msgid "Supports touchscreens"
+msgstr "Stöder pekskärmar"
+
+#: src/bz-hardware-support-dialog.c:81
+msgid "Unknown support for touchscreens"
+msgstr "Okänt stöd för pekskärmar"
+
+#: src/bz-hardware-support-dialog.c:160
+msgid "Mobile support"
+msgstr "Mobilstöd"
+
+#: src/bz-hardware-support-dialog.c:161
+msgid "Works on mobile devices"
+msgstr "Fungerar på mobila enheter"
+
+#: src/bz-hardware-support-dialog.c:161
+msgid "May not work well on mobile devices"
+msgstr "Kanske inte fungerar bra på mobila enheter"
+
+#: src/bz-hardware-support-dialog.c:166
+msgid "Desktop support"
+msgstr "Skrivbordsstöd"
+
+#: src/bz-hardware-support-dialog.c:167
+msgid "Works well on large screens"
+msgstr "Fungerar bäst på stora skärmar"
+
+#: src/bz-hardware-support-dialog.c:201
+#, c-format
+msgid "%s works best on specific hardware"
+msgstr "%s fungerar bäst på specifik hårdvara"
+
+#: src/bz-hardware-support-dialog.c:209
+#, c-format
+msgid "%s works on most devices"
+msgstr "%s fungerar på de flesta enheter"
+
+#: src/bz-inspector.blp:23
+msgid "Inspector Menu"
+msgstr "Inspektörsmeny"
+
+#: src/bz-install-controls.blp:58
+msgid "_Open"
+msgstr "Ö_ppna"
+
+#: src/bz-install-controls.blp:73 src/bz-install-controls.blp:128
+msgid "Uninstall Application"
+msgstr "Avinstallera program"
+
+#: src/bz-install-controls.blp:83 src/bz-transaction-dialog.c:230
+msgid "_Remove"
+msgstr "_Ta bort"
+
+#: src/bz-install-controls.blp:115 src/bz-updates-card.c:168
+#: src/bz-updates-card.c:187
+msgid "Update"
+msgstr "Uppdatera"
+
+#: src/bz-install-controls.blp:138 src/bz-installed-tile.blp:109
+msgid "Remove"
+msgstr "Ta bort"
+
+#: src/bz-install-controls.c:638
+#, c-format
+msgid "Install %s from %s"
+msgstr "Installera %s från %s"
+
+#: src/bz-install-controls.c:640
+#, c-format
+msgid "Install %s"
+msgstr "Installera %s"
+
+#: src/bz-install-controls.wdgt:32
+msgctxt "Install Controls"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: src/bz-install-controls.wdgt:35
+msgctxt "Install Controls"
+msgid "Cancelling"
+msgstr "Avbryter"
+
+#: src/bz-installed-tile.blp:80
+msgid "Donate"
+msgstr "Donera"
+
+#: src/bz-library-page.blp:17
+msgid "Search installed apps"
+msgstr "Sök installerade program"
+
+#: src/bz-library-page.blp:32
+msgid "No Apps Found"
+msgstr "Inga program hittades"
+
+#: src/bz-library-page.blp:49
+msgid "Search Store Instead"
+msgstr "Sök i butiken i stället"
+
+#: src/bz-library-page.blp:86
+msgid "Pending Updates"
+msgstr "Väntande uppdateringar"
+
+#: src/bz-library-page.blp:113
+msgid "Downloads"
+msgstr "Hämtningar"
+
+#: src/bz-library-page.blp:156
+msgid "Recently Uninstalled"
+msgstr "Senast avinstallerade"
+
+#: src/bz-library-page.blp:207
+msgid "Clear Finished Tasks"
+msgstr "Rensa utförda uppgifter"
+
+#: src/bz-library-page.blp:234
+msgid "Sort Options"
+msgstr "Sorteringsalternativ"
+
+#: src/bz-library-page.blp:293
+msgid "Sort By"
+msgstr "Sortera efter"
+
+#: src/bz-library-page.blp:307
+msgid "Name"
+msgstr "Namn"
+
+#: src/bz-library-page.blp:313
+msgid "Size"
+msgstr "Storlek"
+
+#: src/bz-library-page.c:181
+#, c-format
+msgid "No matches found for \"%s\" in the list of installed apps"
+msgstr "Inga matchningar för ”%s” i listan över installerade program"
+
+#: src/bz-library-page.c:194 src/bz-updates-card.c:437
+#, c-format
+msgid "%u Available Update"
+msgid_plural "%u Available Updates"
+msgstr[0] "%u uppdatering tillgänglig"
+msgstr[1] "%u uppdateringar tillgängliga"
+
+#: src/bz-library-page.c:204
+#, c-format
+msgid "%u Installed App"
+msgid_plural "%u Installed Apps"
+msgstr[0] "%u program installerat"
+msgstr[1] "%u program installerade"
+
+#: src/bz-library-page.c:629 src/bz-search-page.c:786
+msgid "No applications found"
+msgstr "Inga program hittades"
+
+#: src/bz-library-page.c:629 src/bz-search-page.c:788
+#, c-format
+msgid "One application found"
+msgid_plural "%u applications found"
+msgstr[0] "Ett program hittades"
+msgstr[1] "%u program hittades"
+
+#: src/bz-license-dialog.blp:87
+msgid "Get Involved"
+msgstr "Engagera dig"
+
+#: src/bz-license-dialog.blp:114
+msgid "Learn More"
+msgstr "Läs mer"
+
+#: src/bz-license-dialog.c:127
+msgid "Unknown License"
+msgstr "Okänd licens"
+
+#: src/bz-license-dialog.c:130
+msgid "Community Built"
+msgstr "Gemenskapsbyggd"
+
+#: src/bz-license-dialog.c:133 src/context-tile-callbacks.c:289
+msgid "Proprietary"
+msgstr "Proprietär"
+
+#: src/bz-license-dialog.c:135 src/context-tile-callbacks.c:291
+msgid "Special License"
+msgstr "Speciell licens"
+
+#: src/bz-license-dialog.c:203
+msgid ""
+"This app is developed in the open by an international community.\n"
+"\n"
+"You can participate and help make it even better."
+msgstr ""
+"Detta program utvecklas öppet av en internationell gemenskap.\n"
+"\n"
+"Du kan bidra och hjälpa till att göra det ännu bättre."
+
+#: src/bz-license-dialog.c:206
+msgid "The license of this app is not known"
+msgstr "Licensen för detta program är okänd"
+
+#: src/bz-license-dialog.c:212
+#, c-format
+msgid ""
+"This app is developed in the open by an international community, and released "
+"under the %s license.\n"
+"\n"
+"You can participate and help make it even better."
+msgstr ""
+"Detta program utvecklas öppet av en internationell gemenskap, och är släppt "
+"under licensen %s.\n"
+"\n"
+"Du kan bidra och hjälpa till att göra det ännu bättre."
+
+#: src/bz-license-dialog.c:220
+msgid ""
+"This app is not developed in the open, so only its developers know how it "
+"works. It may be insecure in ways that are hard to detect, and it may change "
+"without oversight.\n"
+"\n"
+"You may or may not be able to contribute to this app."
+msgstr ""
+"Detta program utvecklas inte öppet, så endast dess utvecklare vet hur det "
+"fungerar. Det kan vara osäkert på sätt som är svåra att upptäcka, och det kan "
+"ändras utan att du kan se vad som ändrats.\n"
+"\n"
+"Du kommer kanske inte kunna bidra till detta program."
+
+#: src/bz-license-dialog.c:226
+#, c-format
+msgid ""
+"This app is developed under the special license %s.\n"
+"\n"
+"You may or may not be able to contribute to this app."
+msgstr ""
+"Detta program utvecklas under den speciella licensen ”%s”.\n"
+"\n"
+"Du kan kanske, eller kanske inte bidra till detta program."
+
+#: src/bz-license-dialog.c:345 src/bz-license-dialog.c:364
+#: src/bz-safety-dialog.blp:103
+msgid "License"
+msgstr "Licens"
+
+#: src/bz-login-page.blp:6 src/bz-login-page.blp:45
+msgid "Connect to Flathub"
+msgstr "Anslut till Flathub"
+
+#: src/bz-login-page.blp:35
+msgid "Something Went Wrong"
+msgstr "Något gick fel"
+
+#: src/bz-login-page.blp:46
+msgid "Log in to sync your favorited apps across devices"
+msgstr "Logga in för att synkronisera dina favoritprogram mellan enheter"
+
+#: src/bz-login-page.blp:113
+msgid "Finish"
+msgstr "Slutför"
+
+#: src/bz-login-page.c:665
+#, c-format
+msgid "Hello, %s!"
+msgstr "Hej, %s!"
+
+#: src/bz-metainfo-preview.c:105
+msgid "Add Icon to Metainfo Preview?"
+msgstr "Lägg till ikon till Metainfo-förhandsgranskning?"
+
+#: src/bz-metainfo-preview.c:108
+msgid ""
+"Metainfo files don't include app icons by themselves. Would you like to select "
+"one manually?"
+msgstr ""
+"Metainfo-filer inkluderar inte programikoner av sig själva. Vill du välja en "
+"manuellt?"
+
+#: src/bz-metainfo-preview.c:111
+msgid "Skip"
+msgstr "Hoppa över"
+
+#: src/bz-metainfo-preview.c:112 src/bz-metainfo-preview.c:163
+msgid "Select Icon"
+msgstr "Välj ikon"
+
+#: src/bz-metainfo-preview.c:166
+msgid "Image Files"
+msgstr "Bildfiler"
+
+#: src/bz-preferences-dialog.blp:19
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: src/bz-preferences-dialog.blp:25
+msgid "Network connection is metered — automatic store data refresh is paused"
+msgstr ""
+"Nätverksanslutningen har datakvoter — automatiska uppdateringar av butiksdata "
+"är pausade"
+
+#: src/bz-preferences-dialog.blp:26 src/bz-window.blp:236 src/bz-window.blp:247
+msgid "Refresh Manually"
+msgstr "Uppdatera manuellt"
+
+#: src/bz-preferences-dialog.blp:31
+msgid "App Updates"
+msgstr "Programuppdateringar"
+
+#: src/bz-preferences-dialog.blp:33
+msgid ""
+"Auto-updates will pause on metered networks or when power saving is on to save "
+"data and battery."
+msgstr ""
+"Automatiska uppdateringar kommer pausas på nätverk med datakvot eller när "
+"strömsparare är på för att spara data och batteri."
+
+#: src/bz-preferences-dialog.blp:36
+msgid "_Automatic"
+msgstr "_Automatiskt"
+
+#: src/bz-preferences-dialog.blp:37
+msgid "Automatically check for and download app updates"
+msgstr "Sök och hämta programuppdateringar automatiskt"
+
+#: src/bz-preferences-dialog.blp:48
+msgid "_Manual"
+msgstr "_Manuellt"
+
+#: src/bz-preferences-dialog.blp:49
+msgid "Checking for and downloading app updates must be done manually"
+msgstr "Sökning och hämtning av programuppdateringar måste göras manuellt"
+
+#: src/bz-preferences-dialog.blp:67
+msgid "Automatic Update _Notifications"
+msgstr "_Aviseringar för automatiska uppdateringar"
+
+#: src/bz-preferences-dialog.blp:68
+msgid "Notify when updates have been automatically installed"
+msgstr "Meddela då uppdateringar har installerats automatiskt"
+
+#: src/bz-preferences-dialog.blp:73
+msgid "Content Filters"
+msgstr "Innehållsfilter"
+
+#: src/bz-preferences-dialog.blp:76
+msgid "_Free Software Only"
+msgstr "Endast _fri programvara"
+
+#: src/bz-preferences-dialog.blp:77
+msgid "Hide proprietary apps when browsing and searching"
+msgstr "Dölj proprietär programvara vid bläddring och sökning"
+
+#: src/bz-preferences-dialog.blp:82
+msgid "F_lathub Results Only"
+msgstr "Endast F_lathub-resultat"
+
+#: src/bz-preferences-dialog.blp:83
+msgid "Limit search and browse results to apps only available on Flathub"
+msgstr ""
+"Begränsa sök- och bläddringsresultat till bara program som finns på Flathub"
+
+#: src/bz-preferences-dialog.blp:88
+msgid "_Verified Results Only"
+msgstr "Endast _verifierade resultat"
+
+#: src/bz-preferences-dialog.blp:89
+msgid "Hide results that are not verified on Flathub"
+msgstr "Dölj resultat som inte är verifierade på Flathub"
+
+#: src/bz-preferences-dialog.blp:94
+msgid "Hide _End-of-Life Apps"
+msgstr "Dölj program som _passerat slutet på sin livstid"
+
+#: src/bz-preferences-dialog.blp:95
+msgid "Hide apps which are no longer supported by their developers"
+msgstr "Dölj program som inte längre stöds av utvecklarna"
+
+#: src/bz-preferences-dialog.blp:101
+msgid "Progress Bar Theme"
+msgstr "Tema för förloppsindikator"
+
+#: src/bz-preferences-dialog.c:39
+msgid "Accent Color"
+msgstr "Accentfärg"
+
+#: src/bz-preferences-dialog.c:40
+msgid "Pride Colors"
+msgstr "Pridefärger"
+
+#: src/bz-preferences-dialog.c:41
+msgid "Lesbian Pride Colors"
+msgstr "Lesbisk pride-färger"
+
+#: src/bz-preferences-dialog.c:42
+msgid "Male Homosexual Pride Colors"
+msgstr "Manlig homosexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:43
+msgid "Transgender Pride Colors"
+msgstr "Transgender-pridefärger"
+
+#: src/bz-preferences-dialog.c:44
+msgid "Nonbinary Pride Colors"
+msgstr "Ickebinär pride-färger"
+
+#: src/bz-preferences-dialog.c:45
+msgid "Bisexual Pride Colors"
+msgstr "Bisexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:46
+msgid "Asexual Pride Colors"
+msgstr "Asexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:47
+msgid "Pansexual Pride Colors"
+msgstr "Pansexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:48
+msgid "Aromantic Pride Colors"
+msgstr "Aromantisk pride-färger"
+
+#: src/bz-preferences-dialog.c:49
+msgid "Genderfluid Pride Colors"
+msgstr "Genderfluid-pridefärger"
+
+#: src/bz-preferences-dialog.c:50
+msgid "Polysexual Pride Colors"
+msgstr "Polysexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:51
+msgid "Omnisexual Pride Colors"
+msgstr "Omnisexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:52
+msgid "Aroace Pride Colors"
+msgstr "Aromantisk asexuell pride-färger"
+
+#: src/bz-preferences-dialog.c:53
+msgid "Agender Pride Colors"
+msgstr "Agender-pridefärger"
+
+#: src/bz-preferences-dialog.c:54
+msgid "Genderqueer Pride Colors"
+msgstr "Genderqueer-pridefärger"
+
+#: src/bz-preferences-dialog.c:55
+msgid "Intersex Pride Colors"
+msgstr "Intersex-pridefärger"
+
+#: src/bz-preferences-dialog.c:56
+msgid "Demigender Pride Colors"
+msgstr "Demigender-pridefärger"
+
+#: src/bz-preferences-dialog.c:57
+msgid "Biromantic Pride Colors"
+msgstr "Biromantisk pride-färger"
+
+#: src/bz-preferences-dialog.c:58
+msgid "Disability Pride Colors"
+msgstr "Funktionshinder-pridefärger"
+
+#: src/bz-preferences-dialog.c:59
+msgid "Femboy Pride Colors"
+msgstr "Femboy-pridefärger"
+
+#: src/bz-preferences-dialog.c:60
+msgid "Neutrois Pride Colors"
+msgstr "Neutrois-pridefärger"
+
+#: src/bz-preferences-dialog.c:280
+msgid "Bazaar needs to run in the background to check for app updates"
+msgstr "Bazaar behöver köras i bakgrunden för att söka programuppdateringar"
+
+#: src/bz-releases-dialog.blp:5 src/bz-updates-card.c:159
+msgid "Version History"
+msgstr "Versionshistorik"
+
+#: src/bz-releases-list.blp:27
+msgid "_Version History"
+msgstr "_Versionshistorik"
+
+#. Translators: something happened less than a day ago
+#: src/bz-releases-list.c:122
+msgid "Today"
+msgstr "I dag"
+
+#. Translators: something happened more than a day ago but less than 2 days ago
+#: src/bz-releases-list.c:125
+msgid "Yesterday"
+msgstr "I går"
+
+#. Translators: something happened days ago
+#: src/bz-releases-list.c:128
+#, c-format
+msgid "%d day ago"
+msgid_plural "%d days ago"
+msgstr[0] "%d dag sedan"
+msgstr[1] "%d dagar sedan"
+
+#. Translators: something happened weeks ago
+#: src/bz-releases-list.c:131
+#, c-format
+msgid "%d week ago"
+msgid_plural "%d weeks ago"
+msgstr[0] "%d vecka sedan"
+msgstr[1] "%d veckor sedan"
+
+#. Translators: something happened months ago
+#: src/bz-releases-list.c:134
+#, c-format
+msgid "%d month ago"
+msgid_plural "%d months ago"
+msgstr[0] "%d månad sedan"
+msgstr[1] "%d månader sedan"
+
+#. Translators: something happened years ago
+#: src/bz-releases-list.c:137
+#, c-format
+msgid "%d year ago"
+msgid_plural "%d years ago"
+msgstr[0] "%d år sedan"
+msgstr[1] "%d år sedan"
+
+#. TRANSLATORS: This is the date string with: day number, month name, year.
+#. i.e. "22 March 2026"
+#: src/bz-releases-list.c:155
+msgid "%e %B %Y"
+msgstr "%e %B %Y"
+
+#: src/bz-releases-list.c:196
+#, c-format
+msgid "Version %s"
+msgstr "Version %s"
+
+#: src/bz-releases-list.c:251
+msgid "No details for this release"
+msgstr "Inga detaljer för denna utgåva"
+
+#: src/bz-releases-list.c:264
+msgid "Get More Information"
+msgstr "Få mer information"
+
+#: src/bz-rich-app-tile.blp:218
+msgid "Uninstall"
+msgstr "Avinstallera"
+
+#. Translators: If you can't find a short enough translation, use "/" to use an icon instead.
+#: src/bz-rich-app-tile.c:383
+msgid "Get"
+msgstr "/"
+
+#: src/bz-safety-dialog.blp:32 src/bz-safety-dialog.c:297
+#: src/safety-calculator.c:161
+msgid "Arbitrary Permissions"
+msgstr "Godtyckliga rättigheter"
+
+#: src/bz-safety-dialog.blp:49
+msgid ""
+"This app has a permission that indirectly allows it to grant itself <b>any "
+"other permission it wants</b>, bypassing the Flatpak sandbox.\n"
+"\n"
+"It can therefore do anything a privileged, non-sandboxed application can do, "
+"such as accessing all your files and connecting to the internet.\n"
+"\n"
+"Viewing the other permissions may still give a better idea of what the app is "
+"likely to do."
+msgstr ""
+"Detta program har en rättighet som indirekt låter det ge sig själv <b>vilken "
+"annan rättighet som helst som det vill ha</b>, vilket åsidosätter Flatpak-"
+"sandlådan.\n"
+"\n"
+"Det kan därmed göra vad som helst som ett privilegierat program utan sandlåda "
+"kan göra, som att komma åt alla dina filer och ansluta till internet.\n"
+"\n"
+"Att se de andra rättigheterna kan ändå ge en bättre idé om vad programmet kan "
+"förväntas göra."
+
+#: src/bz-safety-dialog.blp:53
+msgid "View Other Permissions"
+msgstr "Visa andra rättigheter"
+
+#. TRANSLATORS: short app safety rating label
+#: src/bz-safety-dialog.blp:81 src/context-tile-callbacks.c:402
+msgid "Safe"
+msgstr "Säkert"
+
+#: src/bz-safety-dialog.blp:114
+msgid "App ID"
+msgstr "Program-ID"
+
+#: src/bz-safety-dialog.blp:124
+msgid "SDK"
+msgstr "SDK"
+
+#: src/bz-safety-dialog.blp:158
+msgid ""
+"This app uses an outdated version of the software platform (SDK) and might "
+"contain bugs or security vulnerabilities which will not be fixed."
+msgstr ""
+"Detta program använder en gammal version av programvaruplattformen (SDK) och "
+"kan innehålla fel eller säkerhetssårbarheter som inte kommer fixas."
+
+#: src/bz-safety-dialog.c:283 src/bz-safety-dialog.c:317
+msgid "Safety"
+msgstr "Säkerhet"
+
+#: src/bz-safety-dialog.c:377
+#, c-format
+msgid "%s is Safe"
+msgstr "%s är säkert"
+
+#: src/bz-safety-dialog.c:382
+#, c-format
+msgid "%s has no Unsafe Permissions"
+msgstr "%s har inga osäkra rättigheter"
+
+#: src/bz-safety-dialog.c:387
+#, c-format
+msgid "%s is Probably Safe"
+msgstr "%s är troligen säkert"
+
+#: src/bz-safety-dialog.c:392
+#, c-format
+msgid "%s is Possibly Unsafe"
+msgstr "%s är potentiellt osäkert"
+
+#: src/bz-safety-dialog.c:397
+#, c-format
+msgid "%s is Unsafe"
+msgstr "%s är osäkert"
+
+#: src/bz-screenshot-page.blp:41
+msgid "Back"
+msgstr "Bakåt"
+
+#: src/bz-screenshot-page.blp:71
+msgid "Previous Screenshot"
+msgstr "Föregående skärmbild"
+
+#: src/bz-screenshot-page.blp:81
+msgid "Next Screenshot"
+msgstr "Nästa skärmbild"
+
+#: src/bz-screenshot-page.blp:97
+msgid "Copy Image"
+msgstr "Kopiera bild"
+
+#: src/bz-screenshot-page.blp:160
+msgid "Reset View"
+msgstr "Återställ vy"
+
+#: src/bz-screenshot-page.blp:171
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: src/bz-screenshot-page.blp:181
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: src/bz-screenshots-carousel.blp:6
+msgid "Screenshots Carousel"
+msgstr "Skärmbildskarusell"
+
+#: src/bz-screenshots-carousel.blp:104
+msgid "No Screenshots"
+msgstr "Inga skärmbilder"
+
+#: src/bz-screenshots-carousel.blp:128
+msgid "Open Screenshot Viewer"
+msgstr "Öppna skärmbildsvisare"
+
+#: src/bz-screenshots-carousel.c:308
+#, c-format
+msgid "Screenshot %u %s"
+msgstr "Skärmbild %u %s"
+
+#: src/bz-screenshots-carousel.c:310
+#, c-format
+msgid "Screenshot %u"
+msgstr "Skärmbild %u"
+
+#: src/bz-search-bar.blp:55
+msgid "Clear Search"
+msgstr "Töm sökfält"
+
+#: src/bz-search-filter-popover.blp:18 src/bz-search-page.blp:66
+msgid "Filters"
+msgstr "Filter"
+
+#: src/bz-search-filter-popover.blp:35
+msgid "_Verified"
+msgstr "_Verifierade"
+
+#: src/bz-search-filter-popover.blp:42
+msgid "_Free/Open"
+msgstr "_Fria/öppna"
+
+#: src/bz-search-filter-popover.blp:49
+msgid "Non-_EOL"
+msgstr "Vars _livstid inte är slut"
+
+#: src/bz-search-filter-popover.blp:52
+msgid "Filter out End-of-Life apps"
+msgstr "Filtrera bort program som passerat slutet på sin livstid"
+
+#: src/bz-search-filter-popover.blp:57
+msgid "_Mobile Friendly"
+msgstr "_Mobilvänliga"
+
+#: src/bz-search-filter-popover.blp:64
+msgid "Categories"
+msgstr "Kategorier"
+
+#: src/bz-search-page.blp:45
+msgid "Search Apps, Games, Software"
+msgstr "Sök program, spel"
+
+#: src/bz-search-page.blp:52
+msgid "Search Filters"
+msgstr "Sökfilter"
+
+#: src/bz-search-page.blp:170
+msgid "Browse Categories"
+msgstr "Bläddra kategorier"
+
+#: src/bz-search-page.blp:206
+msgid "Categories Unavailable"
+msgstr "Kategorier är inte tillgängliga"
+
+#: src/bz-search-page.blp:207
+msgid "Search for apps using the search bar above."
+msgstr "Sök efter program med sökfältet ovan."
+
+#: src/bz-search-page.blp:325
+msgid "No Applications Found"
+msgstr "Inga program hittades"
+
+#: src/bz-search-page.c:249
+#, c-format
+msgid "No results found for \"%s\" in Flathub"
+msgstr "Inga resultat hittades för ”%s” i Flathub"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:67
+msgid "Browser"
+msgstr "Webbläsare"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:72
+msgid "Video"
+msgstr "Video"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:82
+msgid "Office"
+msgstr "Kontor"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:87
+msgid "PDF"
+msgstr "PDF"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:92
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:97
+msgid "Messaging"
+msgstr "Snabbmeddelanden"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:102
+msgid "Paint"
+msgstr "Måla"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:107
+msgid "VPN"
+msgstr "VPN"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:112
+msgid "Torrent"
+msgstr "Torrent"
+
+#. Translators: Search suggestion: the english text will be used for the
+#. search regardless of what you put here, so don't worry about the string
+#. yielding poor search results. Focus on correctness and friendliness,
+#. etc
+#: src/bz-search-pill-list.c:117
+msgid "Emulator"
+msgstr "Emulator"
+
+#: src/bz-share-list.c:58
+msgctxt "Project URL Type"
+msgid "Flathub Page"
+msgstr "Flathub-sida"
+
+#: src/bz-share-list.c:59
+msgctxt "Project URL Type"
+msgid "Project Website"
+msgstr "Projektwebbplats"
+
+#: src/bz-share-list.c:60
+msgctxt "Project URL Type"
+msgid "Issue Tracker"
+msgstr "Ärendehanteringssystem"
+
+#: src/bz-share-list.c:61
+msgctxt "Project URL Type"
+msgid "FAQ"
+msgstr "Frågor och svar"
+
+#: src/bz-share-list.c:62
+msgctxt "Project URL Type"
+msgid "Help"
+msgstr "Hjälp"
+
+#: src/bz-share-list.c:63
+msgctxt "Project URL Type"
+msgid "Donate"
+msgstr "Donera"
+
+#: src/bz-share-list.c:64
+msgctxt "Project URL Type"
+msgid "Translate"
+msgstr "Översätt"
+
+#: src/bz-share-list.c:65
+msgctxt "Project URL Type"
+msgid "Contact"
+msgstr "Kontakt"
+
+#: src/bz-share-list.c:66
+msgctxt "Project URL Type"
+msgid "Source Code"
+msgstr "Källkod"
+
+#: src/bz-share-list.c:67
+msgctxt "Project URL Type"
+msgid "Contribute"
+msgstr "Bidra"
+
+#: src/bz-share-list.c:68
+msgctxt "Project URL Type"
+msgid "Manifest"
+msgstr "Manifest"
+
+#: src/bz-share-list.c:326
+msgid "Copy Link"
+msgstr "Kopiera länk"
+
+#. TRANSLATORS: page in the statistics dialog
+#: src/bz-stats-dialog.blp:28
+msgid "Timeline"
+msgstr "Tidslinje"
+
+# Antalet installationer
+#. TRANSLATORS: label prefix shown in graph tooltips, for example: "Installs: 42"
+#: src/bz-stats-dialog.blp:48
+msgid "Installs:"
+msgstr "Installationer:"
+
+#. TRANSLATORS: page in the statistics dialog
+#: src/bz-stats-dialog.blp:58
+msgid "World"
+msgstr "Världen"
+
+#: src/bz-stats-dialog.blp:72
+msgid "Since 4/15/2024"
+msgstr "Sedan 2024-04-15"
+
+#. Translators: M is the suffix for millions
+#: src/bz-stats-dialog.c:126
+#, c-format
+msgid "%.2fM Total Installs"
+msgstr "%.2fM installationer totalt"
+
+#. Translators: K is the suffix for thousands
+#: src/bz-stats-dialog.c:129
+#, c-format
+msgid "%.2fK Total Installs"
+msgstr "%.2fK installationer totalt"
+
+#: src/bz-stats-dialog.c:131
+#, c-format
+msgid "%'d Total Installs"
+msgstr "%'d installationer totalt"
+
+#: src/bz-subcategory-list.c:78
+msgid "No Results Found"
+msgstr "Inga resultat hittades"
+
+#: src/bz-subcategory-list.c:100
+msgid "Search failed"
+msgstr "Sökning misslyckades"
+
+#: src/bz-transaction-dialog.c:154
+msgid "Keep User Data"
+msgstr "Bevara användardata"
+
+#: src/bz-transaction-dialog.c:155
+msgid "Allow restoring personal settings &amp; content"
+msgstr "Tillåt återställande av programinställningar och innehåll"
+
+#: src/bz-transaction-dialog.c:164
+msgid "Delete All Data"
+msgstr "Ta bort alla data"
+
+#: src/bz-transaction-dialog.c:165
+msgid "Permanently erase user data to save space"
+msgstr "Ta permanent bort data för att spara utrymme"
+
+#: src/bz-transaction-dialog.c:190
+#, c-format
+msgid "Install %s?"
+msgstr "Installera %s?"
+
+#: src/bz-transaction-dialog.c:195
+msgid "Select which version to install. May install additional shared components"
+msgstr ""
+"Välj vilken version som ska installeras. Kan installera ytterligare delade "
+"komponenter"
+
+#: src/bz-transaction-dialog.c:197
+msgid "May install additional shared components"
+msgstr "Kan installera ytterligare delade komponenter"
+
+#: src/bz-transaction-dialog.c:200 src/bz-transaction-dialog.c:229
+#: src/bz-transaction-dialog.c:274 src/bz-transaction-dialog.c:576
+msgid "_Cancel"
+msgstr "A_vbryt"
+
+#: src/bz-transaction-dialog.c:201
+msgid "_Install"
+msgstr "_Installera"
+
+#: src/bz-transaction-dialog.c:218
+#, c-format
+msgid "Remove %s?"
+msgstr "Ta bort %s?"
+
+#: src/bz-transaction-dialog.c:221
+msgid "Select which version to remove."
+msgstr "Välj vilken version som ska tas bort."
+
+#: src/bz-transaction-dialog.c:223
+#, c-format
+msgid "It will not be possible to use %s after it is uninstalled."
+msgstr "Det kommer inte vara möjligt att använda %s efter borttagning."
+
+#: src/bz-transaction-dialog.c:246
+#, c-format
+msgid "“%s” is High Risk"
+msgstr "”%s” har hög risk"
+
+#: src/bz-transaction-dialog.c:250
+msgid ""
+"This app has full access to your system, including all <b>your files, browser "
+"history, saved passwords</b>, and more. It also has access to the internet, "
+"meaning it could send your data to outside parties.\n"
+"\n"
+"Because the app is proprietary, it can not be audited for what it does with "
+"these permissions."
+msgstr ""
+"Detta program har fullständig åtkomst till ditt system, inklusive alla <b>dina "
+"filer, webbläsarhistorik, sparade lösenord</b> med mera. Det har också åtkomst "
+"till internet, vilket betyder att det skulle kunna sända dina data till "
+"utomstående.\n"
+"\n"
+"Eftersom programmet är proprietärt så går det inte granska vad det gör med "
+"dessa rättigheter."
+
+#: src/bz-transaction-dialog.c:259
+msgid ""
+"This app uses the legacy X11 windowing system, which allows it to <b>record all "
+"keystrokes, capture screenshots, and monitor other applications</b>. It also "
+"has access to the internet, meaning it could send your data to outside "
+"parties.\n"
+"\n"
+"Because the app is proprietary, it can not be audited for what it does with "
+"these permissions."
+msgstr ""
+"Detta program använder det äldre X11-fönstersystemet, vilket tillåter det att "
+"<b>spela in alla tangenttryckningar, ta skärmbilder, och övervaka andra "
+"program</b>. Det har också åtkomst till internet, vilket betyder att det skulle "
+"kunna sända dina data till utomstående.\n"
+"\n"
+"Eftersom programmet är proprietärt så går det inte granska vad det gör med "
+"dessa rättigheter."
+
+#: src/bz-transaction-dialog.c:275
+msgid "_Install Anyway"
+msgstr "_Installera ändå"
+
+#: src/bz-transaction-dialog.c:330
+msgid "Failed to load transaction dialog"
+msgstr "Misslyckades med att läsa in transaktionsdialog"
+
+#: src/bz-transaction-dialog.c:547
+msgid "All apps are already installed"
+msgstr "Alla program är redan installerade"
+
+#: src/bz-transaction-dialog.c:549
+msgid "_OK"
+msgstr "_OK"
+
+#: src/bz-transaction-dialog.c:565
+#, c-format
+msgid "Install %u App?"
+msgid_plural "Install %u Apps?"
+msgstr[0] "Installera %u program?"
+msgstr[1] "Installera %u program?"
+
+#: src/bz-transaction-dialog.c:573
+msgid ""
+"The following will be installed. Additional shared components may also be "
+"installed"
+msgstr ""
+"Följande kommer installeras. Ytterligare delade komponenter kan också "
+"installeras"
+
+#: src/bz-transaction-dialog.c:574
+#, c-format
+msgid "%d addons will be installed."
+msgstr "%d tillägg kommer installeras."
+
+#: src/bz-transaction-dialog.c:575
+msgid "Additionally, addons will be installed."
+msgstr "Ytterligare kommer tillägg att installeras."
+
+#: src/bz-transaction-dialog.c:577
+msgid "_Install All"
+msgstr "_Installera alla"
+
+#: src/bz-transaction-manager.c:796
+#, c-format
+msgid "Finished in %.02f seconds"
+msgstr "Slutförde på %.02f sekunder"
+
+#: src/bz-transaction-tile.blp:129
+msgid "App Add-On"
+msgstr "Programtillägg"
+
+#: src/bz-transaction-tile.blp:158
+msgid "Runtime"
+msgstr "Exekveringsmiljö"
+
+#: src/bz-transaction-tile.blp:182
+msgid "In Queue"
+msgstr "I kö"
+
+#: src/bz-transaction-tile.blp:206
+msgid "Done"
+msgstr "Färdig"
+
+#: src/bz-transaction-tile.blp:230
+msgid "Cancelled"
+msgstr "Avbruten"
+
+#: src/bz-transaction-tile.blp:254
+msgid "Error"
+msgstr "Fel"
+
+#: src/bz-transaction-tile.blp:313
+msgid "Cancel Transaction"
+msgstr "Avbryt transaktion"
+
+#: src/bz-transaction-tile.blp:323
+msgid "Show Details"
+msgstr "Visa detaljer"
+
+#: src/bz-transaction-tile.blp:438
+msgid "Show Error Info"
+msgstr "Visa felinfo"
+
+#: src/bz-transaction-tile.c:107
+#, c-format
+msgid "%s Freed"
+msgstr "%s frigjort"
+
+#: src/bz-transaction-tile.c:360 src/bz-transaction-tile.c:363
+msgid "Transaction Error"
+msgstr "Transaktionsfel"
+
+#: src/bz-transaction.c:344
+msgid "Pending"
+msgstr "Väntar"
+
+#: src/bz-updates-card.blp:23
+msgid "_Update All"
+msgstr "_Uppdatera alla"
+
+#: src/bz-updates-card.c:215
+#, c-format
+msgid "%u Runtime Update"
+msgid_plural "%u Runtime Updates"
+msgstr[0] "%u exekveringsmiljöuppdatering"
+msgstr[1] "%u exekveringsmiljöuppdateringar"
+
+#: src/bz-user-data-page.blp:5
+msgid "Manage Leftover User Data"
+msgstr "Hantera kvarblivna användardata"
+
+#: src/bz-user-data-page.blp:32
+msgid "No Leftover User Data Found"
+msgstr "Inga kvarblivna användardata hittades"
+
+#: src/bz-user-data-page.blp:33
+msgid "Personal data left behind by apps that were removed will show up here"
+msgstr ""
+"Personliga data som lämnats kvar av program som tagits bort kommer visas här"
+
+#: src/bz-user-data-page.c:229
+#, c-format
+msgid "Trashed User Data for %u App"
+msgid_plural "Trashed User Data for %u Apps"
+msgstr[0] "Kastade användardata för %u program i papperskorgen"
+msgstr[1] "Kastade användardata för %u program i papperskorgen"
+
+#: src/bz-user-data-page.c:233
+#, c-format
+msgid "Trashed User Data for %s"
+msgstr "Kastade användardata för %s i papperskorgen"
+
+#: src/bz-user-data-tile.blp:92
+msgid "Open User Data Folder"
+msgstr "Öppna användardatamapp"
+
+#: src/bz-user-data-tile.blp:103
+msgid "Trash User Data"
+msgstr "Kasta användardata i papperskorgen"
+
+#: src/bz-window.blp:72
+msgid "Refreshing"
+msgstr "Uppdaterar"
+
+#: src/bz-window.blp:90
+msgid "Curated"
+msgstr "Utvalt"
+
+#: src/bz-window.blp:102
+msgid "Explore"
+msgstr "Utforska"
+
+#. Translators: .
+#: src/bz-window.blp:114
+msgid "Library"
+msgstr "Bibliotek"
+
+#: src/bz-window.blp:129
+msgid "Search"
+msgstr "Sök"
+
+#: src/bz-window.blp:216
+msgid "Main Menu"
+msgstr "Huvudmeny"
+
+#: src/bz-window.blp:227
+msgid "You are running a new version of Bazaar!"
+msgstr "Du kör en ny version av Bazaar!"
+
+#: src/bz-window.blp:228
+msgid "See What's New"
+msgstr "Se vad som är nytt"
+
+#: src/bz-window.blp:235
+msgid "You have a network connection but are viewing a cached version of Flathub"
+msgstr "Du har en nätverksanslutning men tittar på en cachad version av Flathub"
+
+#: src/bz-window.blp:246
+msgid "Network connection is metered — automatic refreshes disabled"
+msgstr ""
+"Nätverksanslutningen har datakvoter — automatiska uppdateringar är inaktiverade"
+
+#: src/bz-window.blp:292
+msgid "_Donate to Bazaar"
+msgstr "_Donera till Bazaar"
+
+#: src/bz-window.blp:298
+msgid "_Refresh"
+msgstr "_Uppdatera"
+
+#: src/bz-window.blp:302
+msgid "_Login With Flathub"
+msgstr "_Logga in med Flathub"
+
+#: src/bz-window.blp:308
+msgid "_Manage Leftover User Data"
+msgstr "_Hantera kvarblivna användardata"
+
+#: src/bz-window.blp:314
+msgid "_Preferences"
+msgstr "_Inställningar"
+
+#: src/bz-window.blp:319
+msgid "_Keyboard Shortcuts"
+msgstr "_Tangentbordsgenvägar"
+
+#: src/bz-window.blp:324
+msgid "_About Bazaar"
+msgstr "_Om Bazaar"
+
+#: src/bz-window.blp:330
+msgid "_Quit Bazaar"
+msgstr "A_vsluta Bazaar"
+
+#: src/bz-window.blp:355
+msgid "Log Out"
+msgstr "Logga ut"
+
+#. Translators: %s is the title of the current page
+#: src/bz-window.c:390
+#, c-format
+msgid "Bazaar — %s"
+msgstr "Bazaar — %s"
+
+#: src/bz-window.c:635 src/bz-window.c:673
+msgid "Failed to launch application"
+msgstr "Misslyckades med att starta program"
+
+#: src/bz-window.c:925
+msgid "You can't remove Bazaar from Bazaar!"
+msgstr "Du kör inte ta bort Bazaar från Bazaar!"
+
+#: src/bz-window.c:1238 src/bz-window.c:1272
+msgid "Can't do that right now!"
+msgstr "Kan inte göra det just nu!"
+
+#. Translators: As in, "1 Install" / "100 Installs"
+#: src/bz-world-map.c:604
+msgid "Install"
+msgid_plural "Installs"
+msgstr[0] "installation"
+msgstr[1] "installationer"
+
+#: src/context-tile-callbacks.c:68
+msgid "---"
+msgstr "---"
+
+#. Translators: M is the suffix for millions
+#: src/context-tile-callbacks.c:75
+#, c-format
+msgid "%.*fM"
+msgstr "%.*fM"
+
+#. Translators: K is the suffix for thousands
+#: src/context-tile-callbacks.c:82
+#, c-format
+msgid "%.*fK"
+msgstr "%.*fK"
+
+#: src/context-tile-callbacks.c:92
+#, c-format
+msgid "%d downloads in the last month"
+msgstr "%d hämtningar senaste månaden"
+
+# TODO: %s är storleken
+#. TRANSLATORS: %s is a formatted file size, for example: "128 MB"
+#: src/context-tile-callbacks.c:133
+#, c-format
+msgid "+%s Runtime"
+msgstr "+%s exekveringsmiljö"
+
+#: src/context-tile-callbacks.c:136
+msgid "Download"
+msgstr "Hämta"
+
+#: src/context-tile-callbacks.c:156
+msgid "Size information unavailable"
+msgstr "Storleksinformation är inte tillgänglig"
+
+#: src/context-tile-callbacks.c:159
+#, c-format
+msgid "Download size of %s"
+msgstr "Hämtningsstorlek för %s"
+
+#: src/context-tile-callbacks.c:192
+msgid "All Ages"
+msgstr "Alla åldrar"
+
+#: src/context-tile-callbacks.c:204
+msgid "Age rating information unavailable"
+msgstr "Ingen information för åldersklassificering tillgänglig"
+
+#: src/context-tile-callbacks.c:209
+msgid "Suitable for all ages"
+msgstr "Lämpligt för alla åldrar"
+
+#: src/context-tile-callbacks.c:211
+#, c-format
+msgid "Suitable for ages %d and up"
+msgstr "Lämpligt för åldern %d och uppåt"
+
+#: src/context-tile-callbacks.c:244 src/context-tile-callbacks.c:249
+#: src/context-tile-callbacks.c:277 src/context-tile-callbacks.c:286
+msgid "Unknown"
+msgstr "Okänt"
+
+#: src/context-tile-callbacks.c:254
+#, c-format
+msgid "Free software licensed under %s"
+msgstr "Fri programvara licensierad under %s"
+
+#: src/context-tile-callbacks.c:259
+msgid "Free software"
+msgstr "Fri programvara"
+
+#: src/context-tile-callbacks.c:262
+msgid "Proprietary Software"
+msgstr "Proprietär programvara"
+
+#: src/context-tile-callbacks.c:265
+#, c-format
+msgid "Special License: %s"
+msgstr "Speciell licens: %s"
+
+#. TRANSLATORS: You can omit the "software" part if your translation makes it obvious we're talking about "libre" and not "gratis"
+#: src/context-tile-callbacks.c:283
+msgid "Free Software"
+msgstr "Fri programvara"
+
+#: src/context-tile-callbacks.c:311
+msgid "Adaptive"
+msgstr "Adaptivt"
+
+#: src/context-tile-callbacks.c:311
+msgid "Desktop Only"
+msgstr "Endast skrivbord"
+
+#: src/context-tile-callbacks.c:317
+msgid "Works on desktop, tablets, and phones"
+msgstr "Fungerar på skrivbord, plattor och telefoner"
+
+#: src/context-tile-callbacks.c:318
+msgid "May not work on mobile devices"
+msgstr "Kanske inte fungerar på mobila enheter"
+
+#. TRANSLATORS: short app safety rating label
+#: src/context-tile-callbacks.c:405 src/context-tile-callbacks.c:408
+msgid "Low Risk"
+msgstr "Låg risk"
+
+#. TRANSLATORS: short app safety rating label
+#: src/context-tile-callbacks.c:411
+msgid "Medium Risk"
+msgstr "Medelrisk"
+
+#. TRANSLATORS: short app safety rating label
+#: src/context-tile-callbacks.c:414
+msgid "High Risk"
+msgstr "Hög risk"
+
+#: src/safety-calculator.c:87
+msgid "Unknown Permissions"
+msgstr "Okända rättigheter"
+
+#: src/safety-calculator.c:88
+msgid "Permissions are missing for this app."
+msgstr "Rättigheter saknas för detta program."
+
+#: src/safety-calculator.c:101
+msgid "No Permissions"
+msgstr "Inga rättigheter"
+
+#: src/safety-calculator.c:102
+msgid "App is fully sandboxed"
+msgstr "Programmet körs fullständigt i sandlåda"
+
+#: src/safety-calculator.c:108
+msgid "Network Access"
+msgstr "Nätverksåtkomst"
+
+#: src/safety-calculator.c:109
+msgid "Can access the internet"
+msgstr "Kan ansluta till internet"
+
+#: src/safety-calculator.c:111
+msgid "No Network Access"
+msgstr "Ingen nätverksåtkomst"
+
+#: src/safety-calculator.c:112
+msgid "Cannot access the internet"
+msgstr "Kan inte ansluta till internet"
+
+#: src/safety-calculator.c:117
+msgid "User Device Access"
+msgstr "Åtkomst till användarenheter"
+
+#: src/safety-calculator.c:118
+msgid "Can access devices such as webcams or gaming controllers"
+msgstr "Kan komma åt enheter som webbkameror eller spelkontroller"
+
+#: src/safety-calculator.c:120
+msgid "No User Device Access"
+msgstr "Ingen åtkomst till användarenheter"
+
+#: src/safety-calculator.c:121
+msgid "Cannot access devices such as webcams or gaming controllers"
+msgstr "Kan inte komma åt enheter som webbkameror eller spelkontroller"
+
+#: src/safety-calculator.c:126
+msgid "Input Device Access"
+msgstr "Åtkomst till inmatningsenheter"
+
+#: src/safety-calculator.c:127
+msgid "Can access input devices"
+msgstr "Kan komma åt inmatningsenheter"
+
+#: src/safety-calculator.c:133
+msgid "Microphone Access and Audio Playback"
+msgstr "Åtkomst till mikrofon och ljuduppspelning"
+
+#: src/safety-calculator.c:134
+msgid "Can listen using microphones and play audio without asking permission"
+msgstr "Kan lyssna på mikrofoner och spela upp ljud utan att be om tillåtelse"
+
+#: src/safety-calculator.c:140
+msgid "System Device Access"
+msgstr "Åtkomst till systemenheter"
+
+#: src/safety-calculator.c:141
+msgid "Can access system devices which require elevated permissions"
+msgstr "Kan komma åt systemenheter som kräver höjda rättigheter"
+
+#: src/safety-calculator.c:147
+msgid "Screen Contents Access"
+msgstr "Åtkomst till skärminnehåll"
+
+#: src/safety-calculator.c:148
+msgid "Can access the contents of the screen or other windows"
+msgstr "Kan komma åt innehållet på skärmen eller andra fönster"
+
+#: src/safety-calculator.c:154
+msgid "Legacy Windowing System"
+msgstr "Gammalt fönstersystem"
+
+#: src/safety-calculator.c:155
+msgid "Always uses a legacy windowing system (X11)"
+msgstr "Använder alltid ett gammalt fönstersystem (X11)"
+
+#: src/safety-calculator.c:162
+msgid "Can acquire arbitrary permissions"
+msgstr "Kan erhålla godtyckliga rättigheter"
+
+#: src/safety-calculator.c:168
+msgid "User Settings"
+msgstr "Användarinställningar"
+
+#: src/safety-calculator.c:169
+msgid "Can access and change user settings"
+msgstr "Kan visa och ändra användarinställningar"
+
+#: src/safety-calculator.c:175
+msgid "Full File System Read/Write Access"
+msgstr "Läs/skrivåtkomst för hela filsystemet"
+
+#: src/safety-calculator.c:176
+msgid "Can read and write all data on the file system"
+msgstr "Kan läsa och skriva alla data på filsystemet"
+
+#: src/safety-calculator.c:183
+msgid "Home Folder Read/Write Access"
+msgstr "Läs/skrivåtkomst för hemmapp"
+
+#: src/safety-calculator.c:184
+msgid "Can read and write all data in your home directory"
+msgstr "Kan läsa och skriva alla data i din hemkatalog"
+
+#: src/safety-calculator.c:191
+msgid "Full File System Read Access"
+msgstr "Läsåtkomst för hela filsystemet"
+
+#: src/safety-calculator.c:192
+msgid "Can read all data on the file system"
+msgstr "Kan läsa alla data på filsystemet"
+
+#: src/safety-calculator.c:200
+msgid "Home Folder Read Access"
+msgstr "Läsåtkomst för hemmapp"
+
+#: src/safety-calculator.c:201
+msgid "Can read all data in your home directory"
+msgstr "Kan läsa alla data i din hemkatalog"
+
+#: src/safety-calculator.c:209
+msgid "Download Folder Read/Write Access"
+msgstr "Läs/skrivåtkomst för hämtningsmapp"
+
+#: src/safety-calculator.c:210
+msgid "Can read and write all data in your downloads directory"
+msgstr "Kan läsa och skriva alla data i din hämtningskatalog"
+
+#: src/safety-calculator.c:220
+msgid "Download Folder Read Access"
+msgstr "Läsåtkomst för hämtningsmapp"
+
+#: src/safety-calculator.c:221
+msgid "Can read all data in your downloads directory"
+msgstr "Kan läsa alla data i din hämtningskatalog"
+
+#: src/safety-calculator.c:242
+msgid "Can read and write all data in the directory"
+msgstr "Kan läsa och skriva alla data i katalogen"
+
+#: src/safety-calculator.c:266
+msgid "Can read all data in the directory"
+msgstr "Kan läsa alla data i katalogen"
+
+#: src/safety-calculator.c:281
+msgid "No File System Access"
+msgstr "Ingen filsystemsåtkomst"
+
+#: src/safety-calculator.c:282
+msgid "Cannot access the file system at all"
+msgstr "Kan inte komma åt filsystemet alls"
+
+#: src/safety-calculator.c:289
+msgid "Uses System Services"
+msgstr "Använder systemtjänster"
+
+#: src/safety-calculator.c:290
+msgid "Can request data from non-portal system services"
+msgstr "Kan begära data från systemtjänster utan portal"
+
+#: src/safety-calculator.c:296
+msgid "Uses Session Services"
+msgstr "Använder sessionstjänster"
+
+#: src/safety-calculator.c:297
+msgid "Can request data from non-portal session services"
+msgstr "Kan begära data från sessionstjänster utan portal"
+
+#: src/safety-calculator.c:345
+msgid "No Service Access"
+msgstr "Ingen tjänsteåtkomst"
+
+#: src/safety-calculator.c:346
+msgid "Cannot access non-portal session or system services at all"
+msgstr ""
+"Kan överhuvudtaget inte komma åt sessions- eller systemtjänster utan portal"
+
+#: src/safety-calculator.c:354
+msgid "Verified App Developer"
+msgstr "Verifierad programutvecklare"
+
+#: src/safety-calculator.c:355
+msgid "The developer of this app has been verified to be who they say they are"
+msgstr "Utvecklaren av detta program har bekräftats vara den de påstår sig vara"
+
+#: src/safety-calculator.c:364
+msgid "Proprietary Code"
+msgstr "Proprietär kod"
+
+#: src/safety-calculator.c:365
+msgid ""
+"The source code is not public, so it cannot be independently audited and might "
+"be unsafe"
+msgstr ""
+"Källkoden är inte offentlig, så oberoende granskning kan inte utföras och koden "
+"kan vara osäker"
+
+#: src/safety-calculator.c:375
+msgid "Auditable Code"
+msgstr "Granskningsbar kod"
+
+#: src/safety-calculator.c:376
+msgid ""
+"The source code is public and can be independently audited, which makes the app "
+"more likely to be safe"
+msgstr ""
+"Källkoden är offentlig, så oberoende granskning kan utföras, vilket gör "
+"programmet mer troligt att vara säkert"
+
+#: src/safety-calculator.c:516
+#, c-format
+msgid "Use the %s System Service"
+msgstr "Använd systemtjänsten %s"
+
+#: src/safety-calculator.c:520
+#, c-format
+msgid "Use the %s Session Service"
+msgstr "Använd sessionstjänsten %s"
+
+#: src/safety-calculator.c:524
+#, c-format
+msgid "Use the %s Service"
+msgstr "Använd tjänsten %s"
+
+#: src/safety-calculator.c:534
+msgid "Can see the non-portal service"
+msgstr "Kan se tjänsten utan portal"
+
+#: src/safety-calculator.c:536
+msgid "Can talk to the non-portal service"
+msgstr "Kan prata med tjänsten utan portal"
+
+#: src/safety-calculator.c:538
+msgid "Can own the non-portal service"
+msgstr "Kan äga tjänsten utan portal"
+
+#: src/safety-calculator.c:553
+msgid "Global Menu Integration"
+msgstr "Global menyintegration"
+
+#: src/safety-calculator.c:554
+msgid "Can display its menus in a global menu bar"
+msgstr "Kan visa sina menyer i en global menyrad"
+
+#: src/safety-calculator.c:559
+msgid "KDE Settings Integration"
+msgstr "KDE-inställningsintegration"
+
+#: src/safety-calculator.c:560
+msgid "Can detect when KDE desktop settings change"
+msgstr "Kan upptäcka när KDE-skrivbordsinställningar ändras"
+
+#: src/safety-calculator.c:565
+msgid "KDE Global Settings"
+msgstr "Globala KDE-inställningar"
+
+#: src/safety-calculator.c:566
+msgid "Can read KDE desktop preferences like fonts and colors"
+msgstr "Kan läsa KDE-skrivbordsinställningar som typsnitt och färger"
+
+#: src/safety-calculator.c:571
+msgid "Secret Storage Service"
+msgstr "Lagringstjänst för hemligheter"
+
+#: src/safety-calculator.c:572
+msgid "Can store and retrieve its own passwords using the system keyring"
+msgstr "Kan lagra och hämta sina egna lösenord med systemnyckelringen"
+
+#: src/safety-calculator.c:577
+msgid "Desktop Notifications Service"
+msgstr "Skrivbordsaviseringstjänst"
+
+#: src/safety-calculator.c:578
+msgid "Can send desktop notifications"
+msgstr "Kan skicka skrivbordsaviseringar"
+
+#: src/safety-calculator.c:584
+msgid "System Tray Integration"
+msgstr "Aktivitetsfältsintegration"
+
+#: src/safety-calculator.c:585
+msgid "Can display an icon in the system tray"
+msgstr "Kan visa en ikon i aktivitetsfältet"
+
+#: src/safety-calculator.c:590
+msgid "KDE Connect Integration"
+msgstr "Integration med KDE-anslut"
+
+#: src/safety-calculator.c:591
+msgid "Can interact with devices paired via KDE Connect"
+msgstr "Kan interagera med enheter som parats genom KDE-anslut"
+
+#: src/shortcuts-dialog.blp:5
+msgctxt "shortcut window"
+msgid "Navigation"
+msgstr "Navigering"
+
+#: src/shortcuts-dialog.blp:8
+msgctxt "shortcut window"
+msgid "Open Explore Page"
+msgstr "Öppna sidan Utforska"
+
+#: src/shortcuts-dialog.blp:14
+msgctxt "shortcut window"
+msgid "Open Library Page"
+msgstr "Öppna bibliotekssida"
+
+#: src/shortcuts-dialog.blp:20
+msgctxt "shortcut window"
+msgid "Open Search Page"
+msgstr "Öppna söksida"
+
+#: src/shortcuts-dialog.blp:25
+msgctxt "shortcut window"
+msgid "Remotes"
+msgstr "Fjärrar"
+
+#: src/shortcuts-dialog.blp:27
+msgctxt "shortcut window"
+msgid "Sync Remotes"
+msgstr "Synkronisera fjärrar"
+
+#: src/shortcuts-dialog.blp:33
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allmänt"
+
+#: src/shortcuts-dialog.blp:36
+msgctxt "shortcut window"
+msgid "Open Preferences"
+msgstr "Öppna inställningar"
+
+#: src/shortcuts-dialog.blp:41
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Visa kortkommandon"
+
+#: src/shortcuts-dialog.blp:46
+msgctxt "shortcut window"
+msgid "Close Window"
+msgstr "Stäng fönster"
+
+#: src/shortcuts-dialog.blp:52
+msgctxt "shortcut window"
+msgid "Quit Bazaar"
+msgstr "Avsluta Bazaar"
+
+#: src/transaction-notification.c:133
+#, c-format
+msgid "%s Installed"
+msgstr "%s installerades"
+
+#: src/transaction-notification.c:135
+msgid "The app is ready to be used"
+msgstr "Programmet är redo att användas"
+
+#: src/update-worker.c:263
+msgid "Updates Are Out of Date"
+msgstr "Uppdateringar är inaktuella"
+
+#: src/update-worker.c:264
+msgid "Please check for available updates"
+msgstr "Sök efter tillgängliga uppdateringar"
+
+#: src/update-worker.c:449
+#, c-format
+msgid "%u App Updated"
+msgid_plural "%u Apps Updated"
+msgstr[0] "%u program uppdaterades"
+msgstr[1] "%u program uppdaterades"
+
+#: src/update-worker.c:452
+#, c-format
+msgid "%s has been updated."
+msgstr "%s har uppdaterats."
+
+#: src/update-worker.c:455
+#, c-format
+msgid "%s and %s have been updated."
+msgstr "%s och %s har uppdaterats."
+
+#: src/update-worker.c:459
+#, c-format
+msgid "Includes %s, %s and %s."
+msgstr "Inkluderar %s, %s och %s."
+
+#~ msgid "Donate Button"
+#~ msgstr "Donera-knapp"


### PR DESCRIPTION
Add translation in Swedish from Damned Lies: https://l10n.gnome.org/vertimus/7707/1855/112/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.