### PR TITLE
transaction tile: Make progress label numeric

### DIFF
--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -78,6 +78,7 @@ template $BzTransactionTile: $BzListTile {
                       styles [
                         "dimmed",
                         "caption-heading",
+                        "numeric",
                       ]
 
                       hexpand: true;


### PR DESCRIPTION
This label has a frequently updating number (file size), and the numeric class makes it monospace, so that it doesn't jump around. This is a libadwaita built-in class.

Not sure off the bat if any other labels similarly need this.