### PR TITLE
Update string for Exhibit app page screenshot

### DIFF
--- a/data/io.github.kolunmi.Bazaar.metainfo.xml.in
+++ b/data/io.github.kolunmi.Bazaar.metainfo.xml.in
@@ -56,7 +56,7 @@
     </screenshot>
     <screenshot>
       <image>https://github.com/user-attachments/assets/3de5d9a0-9c5d-461a-964c-7d680cc5f1a2</image>
-      <caption>Exhibit app page</caption>
+      <caption>App page for Exhibit</caption>
     </screenshot>
     <screenshot>
       <image>https://github.com/user-attachments/assets/18424ebc-73a1-41b5-956e-57dcbcb592e6</image>


### PR DESCRIPTION
Multiple translations took it as the verb "exhibit"
rather than an app name. Reorder so it's clearer that it's not the verb.

