### PR TITLE
feat: only track stable flatpak version

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -150,7 +150,7 @@
               "tag": "1.18.0",
               "x-checker-data": {
                 "type": "git",
-                "url-template": "$version",
+                "tag-pattern": "^(1\\.[0-8][02468]\\..*)$",
                 "is-important": true
               }
             }


### PR DESCRIPTION
1.19 was just tagged, we should stick with the stable release series.

We can't use anitya for this because the 1.17 odd release series were not marked as pre-release :/