### PR TITLE
Fix outline of radio buttons in preferences

### DIFF
--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -40,6 +40,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
 
         [prefix]
         CheckButton automatic_updates_check {
+          valign: center;
           toggled => $auto_updates_toggled_cb();
         }
       }
@@ -52,6 +53,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
 
         [prefix]
         CheckButton manual_updates_check {
+          valign: center;
           active: bind automatic_updates_check.active inverted;
           group: automatic_updates_check;
           toggled => $auto_updates_toggled_cb();


### PR DESCRIPTION
Had this exact same issue in the transaction dialog, and still did not learn.