### PR TITLE
Fix doap syntax

### DIFF
--- a/bazaar.doap
+++ b/bazaar.doap
@@ -26,11 +26,11 @@
   <maintainer>
     <foaf:Person>
       <foaf:name>Kolunmi</foaf:name>
+      <foaf:mbox rdf:resource="mailto:kolunmi@posteo.net" />
       <foaf:account>
         <foaf:OnlineAccount>
           <foaf:accountServiceHomepage rdf:resource="https://github.com" />
           <foaf:accountName>kolunmi</foaf:accountName>
-          <foaf:mbox rdf:resource="mailto:kolunmi@posteo.net" />
         </foaf:OnlineAccount>
       </foaf:account>
     </foaf:Person>


### PR DESCRIPTION
l10n.gnome.org requires mbox to be on same level as name of the maintainer


Hopefully enough to get Damned Lies to pick up maintainer this time. At least I got it to work in a VM after doing the same change:

`damnedlies - INFO - retrieve_or_create_person in __init__: Could not retrieve person <DOAPMaintainer: Anders (mail: anders@example.com; account; None)>. This maintainer will be created in the system.`