### PR TITLE
Revert limiter usage for async texture and entry cache manager

### DIFF
--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -20,6 +20,8 @@
 
 #define G_LOG_DOMAIN "BAZAAR::ASYNC-TEXTURE"
 
+#define MAX_CONCURRENT_IO      8
+#define MAX_CONCURRENT_GLYCIN  32
 #define CACHE_INVALID_AGE      (G_TIME_SPAN_DAY * 1)
 #define HTTP_TIMEOUT_SECONDS   5
 #define MAX_LOAD_RETRIES       3
@@ -638,8 +640,7 @@ maybe_load (BzAsyncTexture *self)
   data->retries         = self->retries;
   g_weak_ref_init (&data->self, self);
 
-  future = dex_limiter_run (
-      bz_get_io_limiter (),
+  future = dex_scheduler_spawn (
       bz_get_io_scheduler (),
       bz_get_dex_stack_size (),
       (DexFiberFunc) load_fiber_work,
@@ -654,6 +655,18 @@ maybe_load (BzAsyncTexture *self)
 static DexFuture *
 load_fiber_work (LoadData *data)
 {
+  static GMutex queueing_mutex = { 0 };
+
+  static guint    concurrent_io                 = MAX_CONCURRENT_IO;
+  static guint    io_queued[MAX_CONCURRENT_IO]  = { 0 };
+  static BzGuard *io_gates[MAX_CONCURRENT_IO]   = { 0 };
+  static GMutex   io_mutexes[MAX_CONCURRENT_IO] = { 0 };
+
+  static guint    concurrent_glycin                     = 0;
+  static guint    glycin_queued[MAX_CONCURRENT_GLYCIN]  = { 0 };
+  static BzGuard *glycin_gates[MAX_CONCURRENT_GLYCIN]   = { 0 };
+  static GMutex   glycin_mutexes[MAX_CONCURRENT_GLYCIN] = { 0 };
+
   GFile        *source                  = data->source;
   char         *source_uri              = data->source_uri;
   GFile        *cache_into              = data->cache_into;
@@ -663,12 +676,76 @@ load_fiber_work (LoadData *data)
   g_autoptr (GError) local_error        = NULL;
   g_autoptr (GMutexLocker) locker       = NULL;
   g_autoptr (BzGuard) slot_guard        = NULL;
+  guint    slot_queued                  = G_MAXUINT;
   gboolean is_http                      = FALSE;
   g_autoptr (GDateTime) now             = NULL;
   g_autofree char *async_tex_data_path  = NULL;
   g_autoptr (GFile) async_tex_data_file = NULL;
   g_autoptr (GdkTexture) texture        = NULL;
   g_autoptr (GlyFrame) frame            = NULL;
+
+  locker = g_mutex_locker_new (&queueing_mutex);
+  if (concurrent_glycin == 0)
+    {
+      /* Ensure we don't overload the system with work; aim for # of logical
+         processors divided by 2
+
+        See:
+          https://github.com/bazaar-org/bazaar/issues/497
+          https://docs.gtk.org/glib/func.get_num_processors.html
+
+        Eva Thu, 23 Oct 2025 14:19:44 -0700
+        */
+      concurrent_glycin = MIN (
+          MAX_CONCURRENT_GLYCIN,
+          MAX (1, g_get_num_processors () / 2));
+
+      g_debug ("Allowing %d concurrent texture glycin", concurrent_glycin);
+    }
+  g_clear_pointer (&locker, g_mutex_locker_free);
+
+#define FIND_LOCK(name, _idx)                       \
+  G_STMT_START                                      \
+  {                                                 \
+    locker = g_mutex_locker_new (&queueing_mutex);  \
+                                                    \
+    for (guint i = 0; i < concurrent_##name; i++)   \
+      {                                             \
+        if (name##_queued[i] < slot_queued)         \
+          {                                         \
+            slot_queued = name##_queued[i];         \
+            (_idx)      = i;                        \
+          }                                         \
+      }                                             \
+                                                    \
+    name##_queued[(_idx)]++;                        \
+    g_clear_pointer (&locker, g_mutex_locker_free); \
+  }                                                 \
+  G_STMT_END
+
+#define FINISH_LOCK(name, _idx)                     \
+  G_STMT_START                                      \
+  {                                                 \
+    locker = g_mutex_locker_new (&queueing_mutex);  \
+    name##_queued[(_idx)]--;                        \
+    g_clear_pointer (&locker, g_mutex_locker_free); \
+  }                                                 \
+  G_STMT_END
+
+#define RATE_LIMIT_BEGIN(name)                                 \
+  G_STMT_START                                                 \
+  {                                                            \
+    guint _slot_index = 0;                                     \
+                                                               \
+    FIND_LOCK (name, _slot_index);                             \
+    BZ_BEGIN_GUARD_WITH_CONTEXT (&slot_guard,                  \
+                                 &name##_mutexes[_slot_index], \
+                                 &name##_gates[_slot_index]);  \
+    FINISH_LOCK (name, _slot_index);                           \
+  }                                                            \
+  G_STMT_END
+
+#define RATE_LIMIT_END() bz_clear_guard (&slot_guard)
 
   is_http = g_str_has_prefix (source_uri, "http");
   now     = g_date_time_new_now_utc ();
@@ -680,6 +757,8 @@ load_fiber_work (LoadData *data)
 
   if (cache_into != NULL)
     {
+      RATE_LIMIT_BEGIN (io);
+
       if (g_file_query_exists (cache_into, NULL) &&
           g_file_query_exists (async_tex_data_file, NULL))
         {
@@ -713,6 +792,9 @@ load_fiber_work (LoadData *data)
             {
               if (age_span < CACHE_INVALID_AGE)
                 {
+                  RATE_LIMIT_END ();
+                  RATE_LIMIT_BEGIN (glycin);
+
                   loader = gly_loader_new (cache_into);
                   /* We assume we exported this file, so uhhh it is safe to
                      not use sandboxing, since it is faster :-) */
@@ -721,6 +803,9 @@ load_fiber_work (LoadData *data)
                   image = gly_loader_load (loader, &local_error);
                   if (image != NULL)
                     frame = gly_image_next_frame (image, &local_error);
+
+                  RATE_LIMIT_END ();
+                  RATE_LIMIT_BEGIN (io);
                 }
               else
                 g_debug ("Metadata file %s for cached texture at %s indicates this resource is too old (GTimeSpan: %zu), "
@@ -753,6 +838,8 @@ load_fiber_work (LoadData *data)
                 }
             }
         }
+
+      RATE_LIMIT_END ();
     }
 
   if (frame == NULL)
@@ -767,6 +854,8 @@ load_fiber_work (LoadData *data)
           gboolean reconstruct     = FALSE;
 
           parent = g_file_get_parent (cache_into);
+
+          RATE_LIMIT_BEGIN (io);
 
           if (g_file_query_exists (parent, NULL))
             {
@@ -797,6 +886,8 @@ load_fiber_work (LoadData *data)
                     return dex_future_new_for_error (g_steal_pointer (&local_error));
                 }
             }
+
+          RATE_LIMIT_END ();
         }
 
       if (is_http)
@@ -809,12 +900,16 @@ load_fiber_work (LoadData *data)
               g_autofree char *tmpl        = NULL;
               g_autoptr (GFileIOStream) io = NULL;
 
+              RATE_LIMIT_BEGIN (io);
+
               basename  = g_file_get_basename (source);
               tmpl      = g_strdup_printf ("XXXXXX-%s", basename);
               load_file = g_file_new_tmp (tmpl, &io, &local_error);
               if (load_file == NULL)
                 return dex_future_new_for_error (g_steal_pointer (&local_error));
               g_io_stream_close (G_IO_STREAM (io), NULL, NULL);
+
+              RATE_LIMIT_END ();
             }
 
           result = dex_await (
@@ -833,6 +928,8 @@ load_fiber_work (LoadData *data)
         {
           if (cache_into != NULL)
             {
+              RATE_LIMIT_BEGIN (io);
+
               result = g_file_copy (
                   source, cache_into,
                   G_FILE_COPY_OVERWRITE | G_FILE_COPY_ALL_METADATA,
@@ -840,11 +937,15 @@ load_fiber_work (LoadData *data)
               if (!result)
                 return dex_future_new_for_error (g_steal_pointer (&local_error));
 
+              RATE_LIMIT_END ();
+
               load_file = g_object_ref (cache_into);
             }
           else
             load_file = g_object_ref (source);
         }
+
+      RATE_LIMIT_BEGIN (glycin);
 
       loader = gly_loader_new (load_file);
 #ifdef SANDBOXED_LIBFLATPAK
@@ -861,6 +962,8 @@ load_fiber_work (LoadData *data)
       frame = gly_image_next_frame (image, &local_error);
       if (frame == NULL)
         return dex_future_new_for_error (g_steal_pointer (&local_error));
+
+      RATE_LIMIT_END ();
 
       if (async_tex_data_file != NULL)
         {
@@ -879,6 +982,8 @@ load_fiber_work (LoadData *data)
           variant = g_variant_builder_end (builder);
           bytes   = g_variant_get_data_as_bytes (variant);
 
+          RATE_LIMIT_BEGIN (io);
+
           output = g_file_replace (
               async_tex_data_file,
               NULL,
@@ -894,6 +999,8 @@ load_fiber_work (LoadData *data)
               if (bytes_written > 0)
                 g_output_stream_close (G_OUTPUT_STREAM (output), NULL, &local_error);
             }
+
+          RATE_LIMIT_END ();
 
           if (local_error != NULL)
             g_warning ("Failed to write async-tex cache metadata to %s ;"

--- a/src/bz-entry-cache-manager.c
+++ b/src/bz-entry-cache-manager.c
@@ -21,6 +21,7 @@
 #define G_LOG_DOMAIN  "BAZAAR::ENTRY-CACHE"
 #define BAZAAR_MODULE "entry-cache"
 
+#define MAX_CONCURRENT_WRITES       16
 #define WATCH_CLEANUP_INTERVAL_MSEC 5000
 
 #include <malloc.h>
@@ -43,11 +44,19 @@ struct _BzEntryCacheManager
   GMutex mutex;
   guint  living_entries;
 
+  DexScheduler *scheduler;
+  guint64       memory_usage;
+
   DexPromise *init;
 
   GHashTable *alive_hash;
   GHashTable *writing_hash;
   GHashTable *reading_hash;
+
+  BzGuard *ongoing_gates[MAX_CONCURRENT_WRITES];
+  GMutex   ongoing_mutexes[MAX_CONCURRENT_WRITES];
+  guint    ongoing_queued[MAX_CONCURRENT_WRITES];
+  GMutex   ongoing_queueing_mutex;
 
   BzGuard *alive_gate;
   GMutex   alive_mutex;
@@ -134,12 +143,18 @@ bz_entry_cache_manager_dispose (GObject *object)
 
   g_mutex_clear (&self->mutex);
 
+  dex_clear (&self->scheduler);
   dex_clear (&self->watch_task);
 
   g_clear_pointer (&self->init, dex_unref);
   g_clear_pointer (&self->alive_hash, g_hash_table_unref);
   g_clear_pointer (&self->writing_hash, g_hash_table_unref);
   g_clear_pointer (&self->reading_hash, g_hash_table_unref);
+  for (guint i = 0; i < G_N_ELEMENTS (self->ongoing_gates); i++)
+    g_clear_pointer (&self->ongoing_gates[i], bz_guard_destroy);
+  for (guint i = 0; i < G_N_ELEMENTS (self->ongoing_mutexes); i++)
+    g_mutex_clear (&self->ongoing_mutexes[i]);
+  g_mutex_clear (&self->ongoing_queueing_mutex);
   g_clear_pointer (&self->alive_gate, bz_guard_destroy);
   g_clear_pointer (&self->reading_gate, bz_guard_destroy);
   g_clear_pointer (&self->writing_gate, bz_guard_destroy);
@@ -210,6 +225,8 @@ bz_entry_cache_manager_init (BzEntryCacheManager *self)
 {
   g_mutex_init (&self->mutex);
 
+  self->scheduler = dex_thread_pool_scheduler_new ();
+
   self->init       = dex_promise_new ();
   self->alive_hash = g_hash_table_new_full (
       g_str_hash, g_str_equal, g_free, living_entry_data_unref);
@@ -217,12 +234,15 @@ bz_entry_cache_manager_init (BzEntryCacheManager *self)
       g_str_hash, g_str_equal, g_free, dex_unref);
   self->reading_hash = g_hash_table_new_full (
       g_str_hash, g_str_equal, g_free, dex_unref);
+  for (guint i = 0; i < G_N_ELEMENTS (self->ongoing_mutexes); i++)
+    g_mutex_init (&self->ongoing_mutexes[i]);
+  g_mutex_init (&self->ongoing_queueing_mutex);
   g_mutex_init (&self->alive_mutex);
   g_mutex_init (&self->reading_mutex);
   g_mutex_init (&self->writing_mutex);
 
   self->watch_task = dex_scheduler_spawn (
-      dex_thread_pool_scheduler_get_default (),
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) watch_init_fiber,
       bz_track_weak (self), bz_weak_release);
@@ -261,9 +281,8 @@ bz_entry_cache_manager_add (BzEntryCacheManager *self,
   data->unique_id_checksum = g_strdup (bz_entry_get_unique_id_checksum (entry));
   data->entry              = g_object_ref (entry);
 
-  future = dex_limiter_run (
-      bz_get_io_limiter (),
-      bz_get_io_scheduler (),
+  future = dex_scheduler_spawn (
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) write_task_fiber,
       write_task_data_ref (data),
@@ -285,9 +304,8 @@ bz_entry_cache_manager_get (BzEntryCacheManager *self,
   data->self               = bz_track_weak (self);
   data->unique_id_checksum = g_compute_checksum_for_string (G_CHECKSUM_MD5, unique_id, -1);
 
-  future = dex_limiter_run (
-      bz_get_io_limiter (),
-      bz_get_io_scheduler (),
+  future = dex_scheduler_spawn (
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) read_task_fiber,
       read_task_data_ref (data),
@@ -309,9 +327,8 @@ bz_entry_cache_manager_get_by_checksum (BzEntryCacheManager *self,
   data->self               = bz_track_weak (self);
   data->unique_id_checksum = g_strdup (unique_id_checksum);
 
-  future = dex_limiter_run (
-      bz_get_io_limiter (),
-      bz_get_io_scheduler (),
+  future = dex_scheduler_spawn (
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) read_task_fiber,
       read_task_data_ref (data),
@@ -326,9 +343,8 @@ bz_entry_cache_manager_enumerate_disk (BzEntryCacheManager *self)
 
   dex_return_error_if_fail (BZ_IS_ENTRY_CACHE_MANAGER (self));
 
-  future = dex_limiter_run (
-      bz_get_io_limiter (),
-      bz_get_io_scheduler (),
+  future = dex_scheduler_spawn (
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) enumerate_disk_fiber,
       bz_track_weak (self), bz_weak_release);
@@ -345,6 +361,8 @@ write_task_fiber (WriteTaskData *data)
   g_autoptr (BzGuard) slot_guard          = NULL;
   g_autoptr (BzGuard) other_guard         = NULL;
   g_autoptr (GMutexLocker) locker         = NULL;
+  guint      slot_queued                  = G_MAXUINT;
+  guint      slot_index                   = 0;
   DexFuture *writing_future               = NULL;
   g_autoptr (LivingEntryData) living      = NULL;
   g_autoptr (DexPromise) promise          = NULL;
@@ -373,6 +391,32 @@ write_task_fiber (WriteTaskData *data)
         "Entry with unique ID checksum '%s' cannot be "
         "cached because it is not a flatpak entry",
         unique_id_checksum);
+
+  /* Rate limit to reduce competition for resources
+   * when refresh triggers a flood of requests
+   *
+   * Here we make sure to pick the slot with the
+   * least tasks waiting in line
+   */
+  locker = g_mutex_locker_new (&self->ongoing_queueing_mutex);
+  for (guint i = 0; i < G_N_ELEMENTS (self->ongoing_gates); i++)
+    {
+      if (self->ongoing_queued[i] < slot_queued)
+        {
+          slot_queued = self->ongoing_queued[i];
+          slot_index  = i;
+        }
+    }
+  self->ongoing_queued[slot_index]++;
+  g_clear_pointer (&locker, g_mutex_locker_free);
+
+  BZ_BEGIN_GUARD_WITH_CONTEXT (&slot_guard,
+                               &self->ongoing_mutexes[slot_index],
+                               &self->ongoing_gates[slot_index]);
+
+  locker = g_mutex_locker_new (&self->ongoing_queueing_mutex);
+  self->ongoing_queued[slot_index]--;
+  g_clear_pointer (&locker, g_mutex_locker_free);
 
   dex_await (dex_ref (self->init), NULL);
 
@@ -773,7 +817,7 @@ watch_cb (DexFuture *future,
   bz_weak_get_or_return_reject (self, wr);
 
   return dex_scheduler_spawn (
-      dex_thread_pool_scheduler_get_default (),
+      self->scheduler,
       bz_get_dex_stack_size (),
       (DexFiberFunc) watch_work_fiber,
       bz_track_weak (self), bz_weak_release);


### PR DESCRIPTION
The limiter usage is causing a regression making the icon loading noticeably slower. I have narrowed it down to these 2 files, but the new entry cache manager seems to be the largest source of slowdown.