### PR TITLE
Fix metainfo file to support mobile

### DIFF
--- a/data/io.github.kolunmi.Bazaar.metainfo.xml.in
+++ b/data/io.github.kolunmi.Bazaar.metainfo.xml.in
@@ -23,8 +23,10 @@
     <control>pointing</control>
     <control>keyboard</control>
     <control>touch</control>
-    <display_length compare="ge">360</display_length>
   </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
 
   <developer id="io.github.kolunmi">
     <name>The Bazaar Contributors</name>


### PR DESCRIPTION
display_length seemingly has to be in "requires" if you look at this document: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#control