### PR TITLE
Fix carousel touchpad scrolling at the end of the list

### DIFF
--- a/bge/bge-carousel.c
+++ b/bge/bge-carousel.c
@@ -1143,8 +1143,8 @@ scroll_begin (BgeCarousel              *self,
               GtkEventControllerScroll *controller)
 {
   self->scrolling       = TRUE;
-  self->hscroll_start   = self->motion_x;
-  self->hscroll_current = self->motion_x;
+  self->hscroll_start   = 0;
+  self->hscroll_current = 0;
 }
 
 static void


### PR DESCRIPTION
On the featured apps carousel, once you scroll to the last app, touchpad scrolling stops working, even to go backwards. This fixes the boundary check so you can scroll backwards from the last item. It also clamps the first item rather than overshooting when scrolled to the left, which mirrors the behavior that touch controls do.